### PR TITLE
Draft implementation of RV32I46F.v and its testbench

### DIFF
--- a/RV32I/modules/RV32I46F.v
+++ b/RV32I/modules/RV32I46F.v
@@ -1,0 +1,309 @@
+`include "modules/Program_Counter.v"
+`include "modules/PC_Aligner.v"
+`include "modules/PC_Controller.v"
+`include "modules/PC_Plus_4.v"
+`include "modules/Instruction_Memory.v"
+`include "modules/Instruction_Decoder.v"
+`include "modules/Immediate_Generator.v"
+`include "modules/Control_Unit.v"
+`include "modules/Register_File.v"
+`include "modules/Data_Memory.v"
+`include "modules/ALU_Controller.v"
+`include "modules/ALU.v"
+`include "modules/Branch_Logic.v"
+`include "modules/Byte_Enable_Logic.v"
+`include "modules/CSR_File.v"
+`include "modules/Exception_Detector.v"
+`include "modules/Trap_Controller.v"
+
+`include "modules/headers/alu_src_select.vh"
+`include "modules/headers/rf_wd_select.vh"
+
+module RV32I46F (
+    input clk,
+    input reset
+);
+
+    wire [31:0] pc;
+    wire [31:0] pc_plus_4_signal;
+
+    wire [31:0] raw_next_pc;
+    wire [31:0] next_pc;
+
+    wire [31:0] instruction;
+
+    wire [6:0] opcode;
+    wire [2:0] funct3;
+    wire [6:0] funct7;
+    wire [4:0] rs1;
+    wire [4:0] rs2;
+	wire [4:0] rd;
+    wire [19:0] raw_imm;
+    
+    wire [31:0] imm;
+
+    wire jump;
+	wire branch;
+	wire [1:0] alu_src_A_select;
+	wire [2:0] alu_src_B_select;
+    wire memory_read;
+	wire memory_write;
+    wire pc_stall;
+	wire register_file_write;
+	wire [2:0] register_file_write_data_select;
+
+    wire branch_taken;
+
+    reg [31:0] register_file_write_data;
+    
+    wire [31:0] read_data1;
+    wire [31:0] read_data2;
+
+    wire [3:0] alu_op;
+
+    reg [31:0] src_A;
+    reg [31:0] src_B;
+
+    wire [31:0] alu_result;
+    wire alu_zero;
+	
+    wire [31:0] data_memory_read_data;
+    wire [31:0] data_memory_address;
+	wire [31:0] byte_enable_logic_register_file_write_data;
+    wire [31:0] data_memory_write_data;
+    wire [3:0] write_mask;
+
+    wire csr_write_enable;
+    wire [11:0] csr_address;
+    wire [31:0] csr_read_data;
+
+    wire trapped;
+    wire [2:0]  trap_status;
+
+    wire trap_done;
+    wire debug_mode;
+    wire [31:0] trap_target;
+    wire [11:0] csr_trap_address;
+    wire [31:0] csr_trap_write_data;
+
+
+    ProgramCounter program_counter (
+        .clk(clk),
+        .reset(reset),
+        .next_pc(next_pc),
+        .pc(pc)
+    );
+
+    PCAligner pc_aligner (
+        .raw_next_pc(raw_next_pc),
+        .next_pc(next_pc)
+    );
+
+    PCController pc_controller (
+        .jump(jump),
+	    .branch_taken(branch_taken),
+	    .trapped(1'b0),
+	    .pc(pc),
+        .jump_target(alu_result),
+        .imm(imm),
+	    .trap_target(32'b0),
+	    .pc_stall(1'b0),
+	
+	    .next_pc(raw_next_pc)
+    );
+
+    PCPlus4 pc_plus_4 (
+        .pc(pc),
+        .pc_plus_4(pc_plus_4_signal)
+    );
+
+    InstructionMemory instruction_memory (
+        .pc(pc),
+        .instruction(instruction)
+    );
+
+    InstructionDecoder instruction_decoder (
+        .instr(instruction),
+        .opcode(opcode),
+	    .funct3(funct3),
+	    .funct7(funct7),
+	    .rs1(rs1),
+	    .rs2(rs2),
+	    .rd(rd),
+	    .raw_imm(raw_imm)
+    );
+
+    ImmediateGenerator immediate_generator (
+        .raw_imm(raw_imm),
+        .opcode(opcode),
+        .imm(imm)
+    );
+
+    ControlUnit control_unit (
+        .write_done(1'b1),
+	    .opcode(opcode),
+	    .funct3(funct3),
+        .trap_done(trap_done),
+
+        .jump(jump),
+	    .branch(branch),
+	    .alu_src_A_select(alu_src_A_select),
+	    .alu_src_B_select(alu_src_B_select),
+	    .register_file_write(register_file_write),
+	    .register_file_write_data_select(register_file_write_data_select),
+	    .memory_read(memory_read),
+	    .memory_write(memory_write),
+        .pc_stall(pc_stall),
+        .csr_write_enable(csr_write_enable)
+    );
+
+    RegisterFile register_file (
+        .clk(clk),
+        .read_reg1(rs1),
+        .read_reg2(rs2),
+        .write_reg(rd),
+        .write_data(register_file_write_data),
+        .write_enable(register_file_write),
+	
+        .read_data1(read_data1),
+        .read_data2(read_data2)
+    );
+
+    DataMemory data_memory (
+        .clk(clk),
+        .write_enable(memory_write),
+        .address(alu_result[11:2]),
+        .write_data(data_memory_write_data),
+        .write_mask(write_mask),
+
+        .read_data(data_memory_read_data)
+    );
+
+    ALUController alu_controller (
+        .opcode(opcode),
+	    .funct3(funct3),
+        .funct7_5(funct7[5]),
+        .imm_10(imm[10]),
+	
+        .alu_op(alu_op)
+    );
+
+    ALU alu (
+        .src_A(src_A),
+        .src_B(src_B),
+        .alu_op(alu_op),
+
+        .alu_result(alu_result),
+        .alu_zero(alu_zero)
+    );
+
+    BranchLogic branch_logic (
+        .branch(branch),
+        .funct3(funct3),
+        .alu_zero(alu_zero),
+    
+        .branch_taken(branch_taken)
+    );
+
+    ByteEnableLogic byte_enable_logic (
+        .memory_read(memory_read),
+        .memory_write(memory_write),
+        .funct3(funct3),
+	    .register_file_read_data(read_data2),
+	    .data_memory_read_data(data_memory_read_data),
+	    .address(alu_result),
+	
+	    .register_file_write_data(byte_enable_logic_register_file_write_data),
+	    .data_memory_write_data(data_memory_write_data),
+        .write_mask(write_mask)
+    );
+
+    CSRFile csr_file (
+        .clk(clk),
+        .reset(reset),
+        .csr_write_enable(csr_write_enable),
+        .csr_address(raw_imm[11:0]),
+        .csr_write_data(alu_result),
+
+        .csr_read_data(csr_read_data)
+    );
+
+    ExceptionDetector exception_detector (
+        .opcode(opcode),
+        .funct3(funct3),
+        .funct7(funct7),
+        .raw_imm(raw_imm),
+        .next_pc_lsbs(next_pc[1:0]),
+
+        .trapped(trapped),
+        .trap_status(trap_status)
+    );
+
+    TrapController trap_controller (
+        .clk(clk)
+        .reset(reset),
+        .trap_status(trap_status),
+        .pc(pc),
+        .csr_read_data(csr_read_data)
+
+        .debug_mode(debug_mode),
+        .trap_target(trap_target),
+        .trap_done(trap_done),
+        .csr_write_data(csr_write_data),
+        .csr_trap_address(csr_trap_address),
+        .csr_trap_write_data(csr_trap_write_data)
+    );
+
+    always @(*) begin
+        if (alu_src_A_select == `ALU_SRC_A_RD1) begin
+            src_A = read_data1;
+        end
+        else if (alu_src_A_select == `ALU_SRC_A_PC) begin
+            src_A = pc;
+        end
+        else if (alu_src_A_select == `ALU_SRC_A_RS1) begin
+            src_A = {27'b0, rs1};
+        end
+        else begin
+            src_A = 32'b0;
+        end
+
+        if (alu_src_B_select == `ALU_SRC_B_RD2) begin
+            src_B = read_data2;
+        end
+        else if (alu_src_B_select == `ALU_SRC_B_IMM) begin
+            src_B = imm;
+        end
+        else if (alu_src_B_select == `ALU_SRC_B_SHAMT) begin
+            src_B = {27'b0, imm[4:0]};
+        end
+        else if (alu_src_B_select == `ALU_SRC_B_CSR) begin
+            src_B = csr_read_data;
+        end
+        else begin
+            src_B = 32'b0;
+        end
+
+        case (register_file_write_data_select)
+            `RF_WD_LOAD: begin
+                register_file_write_data = byte_enable_logic_register_file_write_data;
+            end
+            `RF_WD_ALU: begin
+                register_file_write_data = alu_result;
+            end
+            `RF_WD_LUI: begin
+                register_file_write_data = imm;
+            end
+            `RF_WD_JUMP: begin
+                register_file_write_data = pc_plus_4_signal;
+            end
+            `RF_WD_CSR: begin
+                register_file_write_data = csr_read_data;
+            end
+            default: begin
+                register_file_write_data = 32'b0;
+            end
+        endcase
+    end
+
+endmodule

--- a/RV32I/modules/RV32I46F.v
+++ b/RV32I/modules/RV32I46F.v
@@ -30,6 +30,8 @@ module RV32I46F (
     wire [31:0] raw_next_pc;
     wire [31:0] next_pc;
 
+    wire [31:0] im_instruction;
+    wire [31:0] dbg_instruction = 0000000_10111_10110_000_11000_0110011; //add x24 = x22 + x23 = FFFF_FFBC + ABAD_BB02 = ABADBABE
     wire [31:0] instruction;
 
     wire [6:0] opcode;
@@ -105,12 +107,12 @@ module RV32I46F (
     PCController pc_controller (
         .jump(jump),
 	    .branch_taken(branch_taken),
-	    .trapped(1'b0),
+	    .trapped(trapped),
 	    .pc(pc),
         .jump_target(alu_result),
         .imm(imm),
-	    .trap_target(32'b0),
-	    .pc_stall(1'b0),
+	    .trap_target(trap_target),
+	    .pc_stall(pc_stall),
 	
 	    .next_pc(raw_next_pc)
     );
@@ -122,7 +124,7 @@ module RV32I46F (
 
     InstructionMemory instruction_memory (
         .pc(pc),
-        .instruction(instruction)
+        .im_instruction(instruction)
     );
 
     InstructionDecoder instruction_decoder (
@@ -297,7 +299,10 @@ module RV32I46F (
         end
 
         if (debug_mode) begin
-            I
+            instr = dbg_instruction;
+        else begin
+            instr = im_instruction;
+        end
         end
 
         case (register_file_write_data_select)

--- a/RV32I/testbenches/RV32I46F_tb.v
+++ b/RV32I/testbenches/RV32I46F_tb.v
@@ -1,0 +1,34 @@
+`timescale 1ns/1ps
+
+module RV32I46F_tb;
+    reg clk;
+    reg reset;
+
+    RV32I46F rv32i46f (
+        .clk(clk),
+        .reset(reset)
+    );
+
+    // Generate clock signal (period = 10ns)
+    always #5 clk = ~clk;
+
+    initial begin
+        $dumpfile("testbenches/results/waveforms/RV32I46F_tb_result.vcd");
+        $dumpvars(0, rv32i46f);
+
+        $display("==================== RV32I46F Test START ====================");
+
+        clk = 0;
+        reset = 1;
+
+        #10;
+
+        reset = 0;
+
+        #500;
+
+        $display("\n====================  RV32I46F Test END  ====================");
+        $stop;
+    end
+
+endmodule


### PR DESCRIPTION
Still need some debugging and test scenario designing. 
But the draft of the RV32I46Fs' top module design and its testbench file is probably done. 
Now we have to get the changes from Trap_Controller's `rst` to `reset` signal. 
And checkout to Instruction Memory branch to write the RV32I46F's testbench scenario. 
![RV32I46F drawio](https://github.com/user-attachments/assets/27fd4a22-477d-497b-893c-30b6ce2ca98a)
