### PR TITLE
[Feat] Modified signal name by revising instr signal to instruction signal

### DIFF
--- a/RV32I/modules/Instruction_Decoder.v
+++ b/RV32I/modules/Instruction_Decoder.v
@@ -1,7 +1,7 @@
 `include "modules/headers/opcode.vh"
 
 module InstructionDecoder (
-    input [31:0] instr,
+	input [31:0] instruction,
     
     output reg [6:0] opcode,
 	output reg [2:0] funct3,
@@ -11,14 +11,12 @@ module InstructionDecoder (
 	output reg [4:0] rd,
 	output reg [19:0] raw_imm
 );
-
     always @(*) begin
-		opcode = instr[6:0];
-		
+		opcode = instruction[6:0];
         case (opcode)
 			`OPCODE_LUI, `OPCODE_AUIPC: begin // U-type
-                rd = instr[11:7];
-				raw_imm = instr[31:12];
+                rd = instruction[11:7];
+				raw_imm = instruction[31:12];
 				
 				funct3 = 3'b000;
 				rs1 = 5'b00000;
@@ -27,8 +25,8 @@ module InstructionDecoder (
             end
 			
 			`OPCODE_JAL: begin // J-type
-				rd = instr[11:7];
-				raw_imm = {instr[31], instr[19:12], instr[20], instr[30:21]};
+				rd = instruction[11:7];
+				raw_imm = {instruction[31], instruction[19:12], instruction[20], instruction[30:21]};
 				
 				funct3 = 3'b000;
 				rs1 = 5'b00000;
@@ -37,41 +35,41 @@ module InstructionDecoder (
 			end
 			
 			`OPCODE_JALR, `OPCODE_LOAD, `OPCODE_ITYPE, `OPCODE_FENCE, `OPCODE_ENVIRONMENT: begin // I-type
-				rd = instr[11:7];
-				funct3 = instr[14:12];
-				rs1 = instr[19:15];
-				raw_imm = {8'b0, instr[31:20]};
+				rd = instruction[11:7];
+				funct3 = instruction[14:12];
+				rs1 = instruction[19:15];
+				raw_imm = {8'b0, instruction[31:20]};
 				
 				rs2 = 5'b00000;
 				funct7 = 7'b0000000;
 			end
 			
 			`OPCODE_BRANCH: begin // B-type
-				funct3 = instr[14:12];
-				rs1 = instr[19:15];
-				rs2 = instr[24:20];
-				raw_imm = {instr[31], instr[7], instr[30:25], instr[11:8]};
+				funct3 = instruction[14:12];
+				rs1 = instruction[19:15];
+				rs2 = instruction[24:20];
+				raw_imm = {instruction[31], instruction[7], instruction[30:25], instruction[11:8]};
 				
 				rd = 5'b00000;
 				funct7 = 7'b0000000;
 			end
 			
 			`OPCODE_STORE: begin // S-type
-				funct3 = instr[14:12];
-				rs1 = instr[19:15];
-				rs2 = instr[24:20];
-				raw_imm = {8'b0, instr[31:25], instr[11:7]};
+				funct3 = instruction[14:12];
+				rs1 = instruction[19:15];
+				rs2 = instruction[24:20];
+				raw_imm = {8'b0, instruction[31:25], instruction[11:7]};
 				
 				rd = 5'b00000;
 				funct7 = 7'b0000000;
 			end
 			
 			`OPCODE_RTYPE: begin // R type
-				rd = instr[11:7];
-				funct3 = instr[14:12];
-				rs1 = instr[19:15];
-				rs2 = instr[24:20];
-				funct7 = instr[31:25];
+				rd = instruction[11:7];
+				funct3 = instruction[14:12];
+				rs1 = instruction[19:15];
+				rs2 = instruction[24:20];
+				funct7 = instruction[31:25];
 				
 				raw_imm = 32'b0;
 			end

--- a/RV32I/testbenches/Instruction_Decoder_tb.v
+++ b/RV32I/testbenches/Instruction_Decoder_tb.v
@@ -1,7 +1,7 @@
 `timescale 1ns/1ps
 
 module InstructionDecoder_tb;
-    reg [31:0] instr;
+    reg [31:0] instruction;
 
     wire [6:0] opcode;
 	wire [2:0] funct3;
@@ -12,7 +12,7 @@ module InstructionDecoder_tb;
 	wire [19:0] raw_imm;
 
     InstructionDecoder instruction_decoder (
-        .instr(instr),
+        .instruction(instruction),
     
 		.opcode(opcode),
 		.funct3(funct3),
@@ -32,55 +32,55 @@ module InstructionDecoder_tb;
 
         // Test 1: R-type
 		$display("\nR-type instruction: ");
-        instr = 32'b0100000_10101_01010_000_10001_0110011;
+        instruction = 32'b0100000_10101_01010_000_10001_0110011;
 
  		#10;
-        $display("Instruction: %b", instr);
+        $display("Instruction: %b", instruction);
 		$display("R: funct7: %b rs2: %b rs1: %b funct3: %b rd: %b opcode: %b", funct7, rs2, rs1, funct3, rd, opcode);
         $display("Reconstruct: %b", {funct7, rs2, rs1, funct3, rd, opcode});
 
         // Test 2: U-type
 		$display("\nU-type instruction: ");
-        instr = 32'b11100011111110100010_10101_0010111;
+        instruction = 32'b11100011111110100010_10101_0010111;
 
         #10;
-        $display("Instruction: %b", instr);
+        $display("Instruction: %b", instruction);
 		$display("I: raw_imm: %b rs1: %b funct3: %b rd: %b opcode: %b", raw_imm, rs1, funct3, rd, opcode);
         $display("Reconstruct: %b", {raw_imm, rs1, funct3, rd, opcode});
 		
 		// Test 3: S-type
 		$display("\nS-type instruction: ");
-        instr = 32'b1000001_11111_10100_010_01110_0100011;
+        instruction = 32'b1000001_11111_10100_010_01110_0100011;
 
         #10;
-        $display("Instruction: %b", instr);
+        $display("Instruction: %b", instruction);
 		$display("S: raw_imm[11:5]: %b rs2: %b rs1: %b funct3: %b raw_imm[4:0]: %b opcode: %b", raw_imm[11:5], rs2, rs1, funct3, raw_imm[4:0], opcode);
         $display("Reconstruct: %b", {raw_imm[11:5], rs2, rs1, funct3, raw_imm[4:0], opcode});
 		
 		// Test 4: B-type
 		$display("\nB-type instruction: ");
-        instr = 32'b1001001_01101_00101_110_11001_1100011;
+        instruction = 32'b1001001_01101_00101_110_11001_1100011;
 
         #10;
-        $display("Instruction: %b", instr);
+        $display("Instruction: %b", instruction);
 		$display("B: raw_imm[11|9:4]: %b rs2: %b rs1: %b funct3: %b raw_imm[3:0|10]: %b opcode: %b", {raw_imm[11], raw_imm[9:4]}, rs2, rs1, funct3, {raw_imm[3:0], raw_imm[10]}, opcode);
         $display("Reconstruct: %b", {{raw_imm[11], raw_imm[9:4]}, rs2, rs1, funct3, {raw_imm[3:0], raw_imm[10]}, opcode});
 		
 		// Test 5: U-type
 		$display("\nU-type instruction: ");
-        instr = 32'b00011001110111001010_11100_0010111;
+        instruction = 32'b00011001110111001010_11100_0010111;
 
         #10;
-        $display("Instruction: %b", instr);
+        $display("Instruction: %b", instruction);
 		$display("U: raw_imm[19:0]: %b rd: %b opcode: %b", raw_imm[19:0], rd, opcode);
         $display("Reconstruct: %b", {raw_imm[19:0], rd, opcode});
 		
 		// Test 6: J-type
 		$display("\nJ-type instruction: ");
-        instr = 32'b11010001110111001110_00111_1101111;
+        instruction = 32'b11010001110111001110_00111_1101111;
 
         #10;
-        $display("Instruction: %b", instr);
+        $display("Instruction: %b", instruction);
 		$display("J: raw_imm[19|9:0|10|18:11]: %b rd: %b opcode: %b", {raw_imm[19], raw_imm[9:0], raw_imm[10], raw_imm[18:11]}, rd, opcode);
         $display("Reconstruct: %b", {{raw_imm[19], raw_imm[9:0], raw_imm[10], raw_imm[18:11]}, rd, opcode});
 

--- a/RV32I/testbenches/results/Instruction_Decoder_result.vvp
+++ b/RV32I/testbenches/results/Instruction_Decoder_result.vvp
@@ -1,25 +1,25 @@
-#! /usr/bin/vvp
-:ivl_version "12.0 (stable)";
+#! /c/Source/iverilog-install/bin/vvp
+:ivl_version "12.0 (devel)" "(s20150603-1539-g2693dd32b)";
 :ivl_delay_selection "TYPICAL";
 :vpi_time_precision - 12;
-:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/system.vpi";
-:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/vhdl_sys.vpi";
-:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/vhdl_textio.vpi";
-:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/v2005_math.vpi";
-:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/va_math.vpi";
-S_0x555e0a8d9b70 .scope module, "InstructionDecoder_tb" "InstructionDecoder_tb" 2 3;
+:vpi_module "C:\iverilog\lib\ivl\system.vpi";
+:vpi_module "C:\iverilog\lib\ivl\vhdl_sys.vpi";
+:vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
+:vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
+:vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
+S_00000138689e13f0 .scope module, "InstructionDecoder_tb" "InstructionDecoder_tb" 2 3;
  .timescale -9 -12;
-v0x555e0a8fa580_0 .net "funct3", 2 0, v0x555e0a8cb9e0_0;  1 drivers
-v0x555e0a8fa660_0 .net "funct7", 6 0, v0x555e0a8f9de0_0;  1 drivers
-v0x555e0a8fa730_0 .var "instr", 31 0;
-v0x555e0a8fa830_0 .net "opcode", 6 0, v0x555e0a8f9f80_0;  1 drivers
-v0x555e0a8fa900_0 .net "raw_imm", 19 0, v0x555e0a8fa060_0;  1 drivers
-v0x555e0a8fa9a0_0 .net "rd", 4 0, v0x555e0a8fa190_0;  1 drivers
-v0x555e0a8faa70_0 .net "rs1", 4 0, v0x555e0a8fa270_0;  1 drivers
-v0x555e0a8fab40_0 .net "rs2", 4 0, v0x555e0a8fa350_0;  1 drivers
-S_0x555e0a8cb710 .scope module, "instruction_decoder" "InstructionDecoder" 2 14, 3 3 0, S_0x555e0a8d9b70;
+v00000138689e3660_0 .net "funct3", 2 0, v0000013868997070_0;  1 drivers
+v00000138689e3700_0 .net "funct7", 6 0, v00000138689e4cd0_0;  1 drivers
+v0000013868a5a110_0 .var "instruction", 31 0;
+v0000013868a5a4d0_0 .net "opcode", 6 0, v00000138689e1e20_0;  1 drivers
+v0000013868a5a1b0_0 .net "raw_imm", 19 0, v00000138689dcc70_0;  1 drivers
+v0000013868a5a930_0 .net "rd", 4 0, v00000138689dcd10_0;  1 drivers
+v0000013868a5af70_0 .net "rs1", 4 0, v000001386899be70_0;  1 drivers
+v0000013868a5a390_0 .net "rs2", 4 0, v000001386899bf10_0;  1 drivers
+S_00000138689e45e0 .scope module, "instruction_decoder" "InstructionDecoder" 2 14, 3 3 0, S_00000138689e13f0;
  .timescale 0 0;
-    .port_info 0 /INPUT 32 "instr";
+    .port_info 0 /INPUT 32 "instruction";
     .port_info 1 /OUTPUT 7 "opcode";
     .port_info 2 /OUTPUT 3 "funct3";
     .port_info 3 /OUTPUT 7 "funct7";
@@ -27,22 +27,22 @@ S_0x555e0a8cb710 .scope module, "instruction_decoder" "InstructionDecoder" 2 14,
     .port_info 5 /OUTPUT 5 "rs2";
     .port_info 6 /OUTPUT 5 "rd";
     .port_info 7 /OUTPUT 20 "raw_imm";
-v0x555e0a8cb9e0_0 .var "funct3", 2 0;
-v0x555e0a8f9de0_0 .var "funct7", 6 0;
-v0x555e0a8f9ec0_0 .net "instr", 31 0, v0x555e0a8fa730_0;  1 drivers
-v0x555e0a8f9f80_0 .var "opcode", 6 0;
-v0x555e0a8fa060_0 .var "raw_imm", 19 0;
-v0x555e0a8fa190_0 .var "rd", 4 0;
-v0x555e0a8fa270_0 .var "rs1", 4 0;
-v0x555e0a8fa350_0 .var "rs2", 4 0;
-E_0x555e0a8c2b70 .event anyedge, v0x555e0a8f9ec0_0, v0x555e0a8f9f80_0;
-    .scope S_0x555e0a8cb710;
+v0000013868997070_0 .var "funct3", 2 0;
+v00000138689e4cd0_0 .var "funct7", 6 0;
+v00000138689e3100_0 .net "instruction", 31 0, v0000013868a5a110_0;  1 drivers
+v00000138689e1e20_0 .var "opcode", 6 0;
+v00000138689dcc70_0 .var "raw_imm", 19 0;
+v00000138689dcd10_0 .var "rd", 4 0;
+v000001386899be70_0 .var "rs1", 4 0;
+v000001386899bf10_0 .var "rs2", 4 0;
+E_00000138689d9d10 .event anyedge, v00000138689e3100_0, v00000138689e1e20_0;
+    .scope S_00000138689e45e0;
 T_0 ;
-    %wait E_0x555e0a8c2b70;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %wait E_00000138689d9d10;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 7, 0, 2;
-    %store/vec4 v0x555e0a8f9f80_0, 0, 7;
-    %load/vec4 v0x555e0a8f9f80_0;
+    %store/vec4 v00000138689e1e20_0, 0, 7;
+    %load/vec4 v00000138689e1e20_0;
     %dup/vec4;
     %pushi/vec4 55, 0, 7;
     %cmp/u;
@@ -89,374 +89,374 @@ T_0 ;
     %jmp/1 T_0.10, 6;
     %jmp T_0.11;
 T_0.0 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 20, 12, 5;
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
+    %store/vec4 v0000013868997070_0, 0, 3;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.1 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 20, 12, 5;
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
+    %store/vec4 v0000013868997070_0, 0, 3;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.2 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 1, 31, 6;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 8, 12, 5;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 1, 20, 6;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 10, 21, 6;
     %concat/vec4; draw_concat_vec4
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
+    %store/vec4 v0000013868997070_0, 0, 3;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.3 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 8;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 12, 20, 6;
     %concat/vec4; draw_concat_vec4
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.4 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 8;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 12, 20, 6;
     %concat/vec4; draw_concat_vec4
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.5 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 8;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 12, 20, 6;
     %concat/vec4; draw_concat_vec4
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.6 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 8;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 12, 20, 6;
     %concat/vec4; draw_concat_vec4
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.7 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
+    %store/vec4 v000001386899be70_0, 0, 5;
     %pushi/vec4 0, 0, 8;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 12, 20, 6;
     %concat/vec4; draw_concat_vec4
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.8 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v000001386899be70_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 20, 6;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v000001386899bf10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 1, 31, 6;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 1, 7, 4;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 6, 25, 6;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 4, 8, 5;
     %concat/vec4; draw_concat_vec4
     %pad/u 20;
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.9 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v000001386899be70_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 20, 6;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
+    %store/vec4 v000001386899bf10_0, 0, 5;
     %pushi/vec4 0, 0, 8;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 7, 25, 6;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
     %concat/vec4; draw_concat_vec4
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %pushi/vec4 0, 0, 5;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %jmp T_0.11;
 T_0.10 ;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 7, 4;
-    %store/vec4 v0x555e0a8fa190_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v00000138689dcd10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 3, 12, 5;
-    %store/vec4 v0x555e0a8cb9e0_0, 0, 3;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v0000013868997070_0, 0, 3;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 15, 5;
-    %store/vec4 v0x555e0a8fa270_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v000001386899be70_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 5, 20, 6;
-    %store/vec4 v0x555e0a8fa350_0, 0, 5;
-    %load/vec4 v0x555e0a8f9ec0_0;
+    %store/vec4 v000001386899bf10_0, 0, 5;
+    %load/vec4 v00000138689e3100_0;
     %parti/s 7, 25, 6;
-    %store/vec4 v0x555e0a8f9de0_0, 0, 7;
+    %store/vec4 v00000138689e4cd0_0, 0, 7;
     %pushi/vec4 0, 0, 20;
-    %store/vec4 v0x555e0a8fa060_0, 0, 20;
+    %store/vec4 v00000138689dcc70_0, 0, 20;
     %jmp T_0.11;
 T_0.11 ;
     %pop/vec4 1;
     %jmp T_0;
     .thread T_0, $push;
-    .scope S_0x555e0a8d9b70;
+    .scope S_00000138689e13f0;
 T_1 ;
     %vpi_call 2 27 "$dumpfile", "testbenches/results/waveforms/Instruction_Decoder_tb_result.vcd" {0 0 0};
-    %vpi_call 2 28 "$dumpvars", 32'sb00000000000000000000000000000000, S_0x555e0a8cb710 {0 0 0};
+    %vpi_call 2 28 "$dumpvars", 32'sb00000000000000000000000000000000, S_00000138689e45e0 {0 0 0};
     %vpi_call 2 31 "$display", "==================== Instruction Decoder Test START ====================" {0 0 0};
     %vpi_call 2 34 "$display", "\012R-type instruction: " {0 0 0};
     %pushi/vec4 1096091827, 0, 32;
-    %store/vec4 v0x555e0a8fa730_0, 0, 32;
+    %store/vec4 v0000013868a5a110_0, 0, 32;
     %delay 10000, 0;
-    %vpi_call 2 38 "$display", "Instruction: %b", v0x555e0a8fa730_0 {0 0 0};
-    %vpi_call 2 39 "$display", "R: funct7: %b rs2: %b rs1: %b funct3: %b rd: %b opcode: %b", v0x555e0a8fa660_0, v0x555e0a8fab40_0, v0x555e0a8faa70_0, v0x555e0a8fa580_0, v0x555e0a8fa9a0_0, v0x555e0a8fa830_0 {0 0 0};
-    %load/vec4 v0x555e0a8fa660_0;
-    %load/vec4 v0x555e0a8fab40_0;
+    %vpi_call 2 38 "$display", "Instruction: %b", v0000013868a5a110_0 {0 0 0};
+    %vpi_call 2 39 "$display", "R: funct7: %b rs2: %b rs1: %b funct3: %b rd: %b opcode: %b", v00000138689e3700_0, v0000013868a5a390_0, v0000013868a5af70_0, v00000138689e3660_0, v0000013868a5a930_0, v0000013868a5a4d0_0 {0 0 0};
+    %load/vec4 v00000138689e3700_0;
+    %load/vec4 v0000013868a5a390_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8faa70_0;
+    %load/vec4 v0000013868a5af70_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa580_0;
+    %load/vec4 v00000138689e3660_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa9a0_0;
+    %load/vec4 v0000013868a5a930_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa830_0;
+    %load/vec4 v0000013868a5a4d0_0;
     %concat/vec4; draw_concat_vec4
     %vpi_call 2 40 "$display", "Reconstruct: %b", S<0,vec4,u32> {1 0 0};
     %vpi_call 2 43 "$display", "\012U-type instruction: " {0 0 0};
     %pushi/vec4 3824822935, 0, 32;
-    %store/vec4 v0x555e0a8fa730_0, 0, 32;
+    %store/vec4 v0000013868a5a110_0, 0, 32;
     %delay 10000, 0;
-    %vpi_call 2 47 "$display", "Instruction: %b", v0x555e0a8fa730_0 {0 0 0};
-    %vpi_call 2 48 "$display", "I: raw_imm: %b rs1: %b funct3: %b rd: %b opcode: %b", v0x555e0a8fa900_0, v0x555e0a8faa70_0, v0x555e0a8fa580_0, v0x555e0a8fa9a0_0, v0x555e0a8fa830_0 {0 0 0};
-    %load/vec4 v0x555e0a8fa900_0;
-    %load/vec4 v0x555e0a8faa70_0;
+    %vpi_call 2 47 "$display", "Instruction: %b", v0000013868a5a110_0 {0 0 0};
+    %vpi_call 2 48 "$display", "I: raw_imm: %b rs1: %b funct3: %b rd: %b opcode: %b", v0000013868a5a1b0_0, v0000013868a5af70_0, v00000138689e3660_0, v0000013868a5a930_0, v0000013868a5a4d0_0 {0 0 0};
+    %load/vec4 v0000013868a5a1b0_0;
+    %load/vec4 v0000013868a5af70_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa580_0;
+    %load/vec4 v00000138689e3660_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa9a0_0;
+    %load/vec4 v0000013868a5a930_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa830_0;
+    %load/vec4 v0000013868a5a4d0_0;
     %concat/vec4; draw_concat_vec4
     %vpi_call 2 49 "$display", "Reconstruct: %b", S<0,vec4,u40> {1 0 0};
     %vpi_call 2 52 "$display", "\012S-type instruction: " {0 0 0};
     %pushi/vec4 2214209315, 0, 32;
-    %store/vec4 v0x555e0a8fa730_0, 0, 32;
+    %store/vec4 v0000013868a5a110_0, 0, 32;
     %delay 10000, 0;
-    %vpi_call 2 56 "$display", "Instruction: %b", v0x555e0a8fa730_0 {0 0 0};
-    %vpi_call 2 57 "$display", "S: raw_imm[11:5]: %b rs2: %b rs1: %b funct3: %b raw_imm[4:0]: %b opcode: %b", &PV<v0x555e0a8fa900_0, 5, 7>, v0x555e0a8fab40_0, v0x555e0a8faa70_0, v0x555e0a8fa580_0, &PV<v0x555e0a8fa900_0, 0, 5>, v0x555e0a8fa830_0 {0 0 0};
-    %load/vec4 v0x555e0a8fa900_0;
+    %vpi_call 2 56 "$display", "Instruction: %b", v0000013868a5a110_0 {0 0 0};
+    %vpi_call 2 57 "$display", "S: raw_imm[11:5]: %b rs2: %b rs1: %b funct3: %b raw_imm[4:0]: %b opcode: %b", &PV<v0000013868a5a1b0_0, 5, 7>, v0000013868a5a390_0, v0000013868a5af70_0, v00000138689e3660_0, &PV<v0000013868a5a1b0_0, 0, 5>, v0000013868a5a4d0_0 {0 0 0};
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 7, 5, 4;
-    %load/vec4 v0x555e0a8fab40_0;
+    %load/vec4 v0000013868a5a390_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8faa70_0;
+    %load/vec4 v0000013868a5af70_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa580_0;
+    %load/vec4 v00000138689e3660_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 5, 0, 2;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa830_0;
+    %load/vec4 v0000013868a5a4d0_0;
     %concat/vec4; draw_concat_vec4
     %vpi_call 2 58 "$display", "Reconstruct: %b", S<0,vec4,u32> {1 0 0};
     %vpi_call 2 61 "$display", "\012B-type instruction: " {0 0 0};
     %pushi/vec4 2463296739, 0, 32;
-    %store/vec4 v0x555e0a8fa730_0, 0, 32;
+    %store/vec4 v0000013868a5a110_0, 0, 32;
     %delay 10000, 0;
-    %vpi_call 2 65 "$display", "Instruction: %b", v0x555e0a8fa730_0 {0 0 0};
-    %load/vec4 v0x555e0a8fa900_0;
+    %vpi_call 2 65 "$display", "Instruction: %b", v0000013868a5a110_0 {0 0 0};
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 11, 5;
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 6, 4, 4;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 4, 0, 2;
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 10, 5;
     %concat/vec4; draw_concat_vec4
-    %vpi_call 2 66 "$display", "B: raw_imm[11|9:4]: %b rs2: %b rs1: %b funct3: %b raw_imm[3:0|10]: %b opcode: %b", S<1,vec4,u7>, v0x555e0a8fab40_0, v0x555e0a8faa70_0, v0x555e0a8fa580_0, S<0,vec4,u5>, v0x555e0a8fa830_0 {2 0 0};
-    %load/vec4 v0x555e0a8fa900_0;
+    %vpi_call 2 66 "$display", "B: raw_imm[11|9:4]: %b rs2: %b rs1: %b funct3: %b raw_imm[3:0|10]: %b opcode: %b", S<1,vec4,u7>, v0000013868a5a390_0, v0000013868a5af70_0, v00000138689e3660_0, S<0,vec4,u5>, v0000013868a5a4d0_0 {2 0 0};
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 11, 5;
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 6, 4, 4;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fab40_0;
+    %load/vec4 v0000013868a5a390_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8faa70_0;
+    %load/vec4 v0000013868a5af70_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa580_0;
+    %load/vec4 v00000138689e3660_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 4, 0, 2;
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 10, 5;
     %concat/vec4; draw_concat_vec4
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa830_0;
+    %load/vec4 v0000013868a5a4d0_0;
     %concat/vec4; draw_concat_vec4
     %vpi_call 2 67 "$display", "Reconstruct: %b", S<0,vec4,u32> {1 0 0};
     %vpi_call 2 70 "$display", "\012U-type instruction: " {0 0 0};
     %pushi/vec4 433892887, 0, 32;
-    %store/vec4 v0x555e0a8fa730_0, 0, 32;
+    %store/vec4 v0000013868a5a110_0, 0, 32;
     %delay 10000, 0;
-    %vpi_call 2 74 "$display", "Instruction: %b", v0x555e0a8fa730_0 {0 0 0};
-    %vpi_call 2 75 "$display", "U: raw_imm[19:0]: %b rd: %b opcode: %b", v0x555e0a8fa900_0, v0x555e0a8fa9a0_0, v0x555e0a8fa830_0 {0 0 0};
-    %load/vec4 v0x555e0a8fa900_0;
-    %load/vec4 v0x555e0a8fa9a0_0;
+    %vpi_call 2 74 "$display", "Instruction: %b", v0000013868a5a110_0 {0 0 0};
+    %vpi_call 2 75 "$display", "U: raw_imm[19:0]: %b rd: %b opcode: %b", v0000013868a5a1b0_0, v0000013868a5a930_0, v0000013868a5a4d0_0 {0 0 0};
+    %load/vec4 v0000013868a5a1b0_0;
+    %load/vec4 v0000013868a5a930_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa830_0;
+    %load/vec4 v0000013868a5a4d0_0;
     %concat/vec4; draw_concat_vec4
     %vpi_call 2 76 "$display", "Reconstruct: %b", S<0,vec4,u32> {1 0 0};
     %vpi_call 2 79 "$display", "\012J-type instruction: " {0 0 0};
     %pushi/vec4 3520914415, 0, 32;
-    %store/vec4 v0x555e0a8fa730_0, 0, 32;
+    %store/vec4 v0000013868a5a110_0, 0, 32;
     %delay 10000, 0;
-    %vpi_call 2 83 "$display", "Instruction: %b", v0x555e0a8fa730_0 {0 0 0};
-    %load/vec4 v0x555e0a8fa900_0;
+    %vpi_call 2 83 "$display", "Instruction: %b", v0000013868a5a110_0 {0 0 0};
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 19, 6;
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 10, 0, 2;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 10, 5;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 8, 11, 5;
     %concat/vec4; draw_concat_vec4
-    %vpi_call 2 84 "$display", "J: raw_imm[19|9:0|10|18:11]: %b rd: %b opcode: %b", S<0,vec4,u20>, v0x555e0a8fa9a0_0, v0x555e0a8fa830_0 {1 0 0};
-    %load/vec4 v0x555e0a8fa900_0;
+    %vpi_call 2 84 "$display", "J: raw_imm[19|9:0|10|18:11]: %b rd: %b opcode: %b", S<0,vec4,u20>, v0000013868a5a930_0, v0000013868a5a4d0_0 {1 0 0};
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 19, 6;
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 10, 0, 2;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 1, 10, 5;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa900_0;
+    %load/vec4 v0000013868a5a1b0_0;
     %parti/s 8, 11, 5;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa9a0_0;
+    %load/vec4 v0000013868a5a930_0;
     %concat/vec4; draw_concat_vec4
-    %load/vec4 v0x555e0a8fa830_0;
+    %load/vec4 v0000013868a5a4d0_0;
     %concat/vec4; draw_concat_vec4
     %vpi_call 2 85 "$display", "Reconstruct: %b", S<0,vec4,u32> {1 0 0};
     %vpi_call 2 87 "$display", "\012====================  Instruction Decoder Test END  ====================" {0 0 0};

--- a/RV32I/testbenches/results/waveforms/Instruction_Decoder_tb_result.vcd
+++ b/RV32I/testbenches/results/waveforms/Instruction_Decoder_tb_result.vcd
@@ -1,5 +1,5 @@
 $date
-	Sun Mar  2 06:37:57 2025
+	Sun May 18 20:43:43 2025
 $end
 $version
 	Icarus Verilog
@@ -9,7 +9,7 @@ $timescale
 $end
 $scope module InstructionDecoder_tb $end
 $scope module instruction_decoder $end
-$var wire 32 ! instr [31:0] $end
+$var wire 32 ! instruction [31:0] $end
 $var reg 3 " funct3 [2:0] $end
 $var reg 7 # funct7 [6:0] $end
 $var reg 7 $ opcode [6:0] $end


### PR DESCRIPTION
While modifying the **Instruction Decoder** to resolve the instruction selection issue between `dbg_instruction` (debug instruction) and `im_instruction` (instruction memory instruction), the **Instruction Decoder** previously included both `dbg_instruction` and `im_instruction` internally for selecting the instruction to decode.

Eventually, this selection functionality was initially addressed internally but was later moved to the top-level module **RV32I46F.R5**, aligning with the original processor design that placed the **MUX** externally, similar to other **MUX** configurations.

At that stage, the selected instruction, determined by the `debug_mode` control signal, was needed. Consequently, it was decided to rename the existing signal instr to the more explicit name instruction. 

This commit reflects the reasoning behind this change.
![RV32I46F R5 drawio](https://github.com/user-attachments/assets/b66c6397-5762-4567-bd7a-1fa3b6df36f3)
