### PR TITLE
[Feat] Add rd signal from to each pipeline registers

### DIFF
--- a/RV32I/modules/EX_MEM_Register.v
+++ b/RV32I/modules/EX_MEM_Register.v
@@ -16,6 +16,7 @@ module EX_MEM_Register #(
     input wire EX_csr_write_enable,
     input wire [6:0] EX_opcode,
     input wire [2:0] EX_funct3,
+    input wire [4:0] EX_rd,
     input wire [XLEN-1:0] EX_read_data2, // Register File to Data Memory read data
     input wire [XLEN-1:0] EX_imm,
     input wire [XLEN-1:0] EX_csr_read_data,
@@ -33,6 +34,7 @@ module EX_MEM_Register #(
     output reg MEM_csr_write_enable,
     output reg [6:0] MEM_opcode,
     output reg [2:0] MEM_funct3,
+    output reg [4:0] MEM_rd,
     output reg [XLEN-1:0] MEM_read_data2,
     output reg [XLEN-1:0] MEM_imm,
     output reg [XLEN-1:0] MEM_csr_read_data,
@@ -51,6 +53,7 @@ always @(posedge clk or posedge reset) begin
         MEM_csr_write_enable <= 1'b0;
         MEM_opcode <= 7'b0;
         MEM_funct3 <= 3'b0;
+        MEM_rd <= 5'b0;
         MEM_read_data2 <= {XLEN{1'b0}};
         MEM_imm <= {XLEN{1'b0}};
         MEM_csr_read_data <= {XLEN{1'b0}};
@@ -66,6 +69,7 @@ always @(posedge clk or posedge reset) begin
         MEM_csr_write_enable <= EX_csr_write_enable;
         MEM_opcode <= EX_opcode;
         MEM_funct3 <= EX_funct3;
+        MEM_rd <= EX_rd;
         MEM_read_data2 <= EX_read_data2;
         MEM_imm <= EX_imm;
         MEM_csr_read_data <= EX_csr_read_data;

--- a/RV32I/modules/ID_EX_Register.v
+++ b/RV32I/modules/ID_EX_Register.v
@@ -27,6 +27,7 @@ module ID_EX_Register #(
     input wire [6:0] ID_opcode, 
     input wire [2:0] ID_funct3,
     input wire [6:0] ID_funct7,
+    input wire [4:0] ID_rd,
     input wire [11:0] ID_raw_imm,
     input wire [XLEN-1:0] ID_read_data1,
     input wire [XLEN-1:0] ID_read_data2,
@@ -51,6 +52,7 @@ module ID_EX_Register #(
     output reg [6:0] EX_opcode,
     output reg [2:0] EX_funct3,
     output reg [6:0] EX_funct7,
+    output reg [4:0] EX_rd,
     output reg [11:0] EX_raw_imm,
     output reg [XLEN-1:0] EX_read_data1,
     output reg [XLEN-1:0] EX_read_data2,
@@ -77,6 +79,7 @@ always @(posedge clk or posedge reset) begin
         EX_opcode <= 7'b0;
         EX_funct3 <= 3'b0;
         EX_funct7 <= 7'b0;
+        EX_rd <= 5'b0;
         EX_raw_imm <= 12'b0;
         EX_read_data1 <= {XLEN{1'b0}};
         EX_read_data2 <= {XLEN{1'b0}};
@@ -100,6 +103,7 @@ always @(posedge clk or posedge reset) begin
         EX_opcode <= ID_opcode;
         EX_funct3 <= ID_funct3;
         EX_funct7 <= ID_funct7;
+        EX_rd <= ID_rd;
         EX_raw_imm <= ID_raw_imm;
         EX_read_data1 <= ID_read_data1;
         EX_read_data2 <= ID_read_data2;

--- a/RV32I/modules/MEM_WB_Register.v
+++ b/RV32I/modules/MEM_WB_Register.v
@@ -15,6 +15,7 @@ module MEM_WB_Register #(
     input wire [XLEN-1:0] MEM_alu_result,
     input wire MEM_register_write_enable,
     input wire MEM_csr_write_enable,
+    input wire [4:0] MEM_rd,
 
     // signals from MEM phase
     input wire [XLEN-1:0] MEM_register_file_write_data,
@@ -28,6 +29,7 @@ module MEM_WB_Register #(
     output reg [XLEN-1:0] WB_alu_result,
     output reg WB_register_write_enable,
     output reg WB_csr_write_enable,
+    output reg [4:0] WB_rd,
 
     output reg [XLEN-1:0] WB_register_file_write_data
 );
@@ -42,6 +44,7 @@ always @(posedge clk or posedge reset) begin
         WB_alu_result <= {XLEN{1'b0}};
         WB_register_write_enable <= 1'b0;
         WB_csr_write_enable <= 1'b0;
+        WB_rd <= 5'b0;
         
         WB_register_file_write_data <= {XLEN{1'b0}};
     end else begin
@@ -53,6 +56,7 @@ always @(posedge clk or posedge reset) begin
         WB_alu_result <= MEM_alu_result;
         WB_register_write_enable <= MEM_register_write_enable;
         WB_csr_write_enable <= MEM_csr_write_enable;
+        WB_rd <= MEM_rd;
         
         WB_register_file_write_data <= MEM_register_file_write_data;
     end

--- a/RV32I/testbenches/EX_MEM_Register_tb.v
+++ b/RV32I/testbenches/EX_MEM_Register_tb.v
@@ -16,6 +16,7 @@ module EX_MEM_Register_tb;
     reg EX_csr_write_enable;
     reg [6:0] EX_opcode; 
     reg [2:0] EX_funct3;
+    reg [4:0] EX_rd;
     reg [XLEN-1:0] EX_read_data2;
     reg [XLEN-1:0] EX_imm;
     reg [XLEN-1:0] EX_csr_read_data;
@@ -31,6 +32,7 @@ module EX_MEM_Register_tb;
     wire MEM_csr_write_enable;
     wire [6:0] MEM_opcode;
     wire [2:0] MEM_funct3;
+    wire [4:0] MEM_rd;
     wire [XLEN-1:0] MEM_read_data2;
     wire [XLEN-1:0] MEM_imm;
     wire [XLEN-1:0] MEM_csr_read_data;
@@ -51,6 +53,7 @@ module EX_MEM_Register_tb;
         .EX_csr_write_enable(EX_csr_write_enable),
         .EX_opcode(EX_opcode),
         .EX_funct3(EX_funct3),
+        .EX_rd(EX_rd),
         .EX_read_data2(EX_read_data2),
         .EX_imm(EX_imm),
         .EX_csr_read_data(EX_csr_read_data),
@@ -66,6 +69,7 @@ module EX_MEM_Register_tb;
         .MEM_csr_write_enable(MEM_csr_write_enable),
         .MEM_opcode(MEM_opcode),
         .MEM_funct3(MEM_funct3),
+        .MEM_rd(MEM_rd),
         .MEM_read_data2(MEM_read_data2),
         .MEM_imm(MEM_imm),
         .MEM_csr_read_data(MEM_csr_read_data),
@@ -90,8 +94,8 @@ module EX_MEM_Register_tb;
         $display("Input now");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
         $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
-        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
         #10;
         
         // Test 1
@@ -104,6 +108,7 @@ module EX_MEM_Register_tb;
         EX_csr_write_enable = 1'b0;
         EX_opcode                  = 7'b0100011;      // STORE opcode
         EX_funct3                  = 3'b010;          // SW
+        EX_rd                      = 5'b01100;
         EX_read_data2              = 32'hDEAD_BEEF;   // Write Data
         EX_imm                     = 32'h0000_0010;   // offset 16
         EX_csr_read_data           = 32'h0000_0000;   // no CSR
@@ -112,7 +117,8 @@ module EX_MEM_Register_tb;
         @(posedge clk); #1;
         $display("Test 1: Previous value should be output now");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
-        $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
         $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
         
         // Test 2@(posedge clk); #1;
@@ -120,8 +126,8 @@ module EX_MEM_Register_tb;
         $display("Test 2: No input(should be same)");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
         $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
-        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
 
         // Test 3
         @(negedge clk); 
@@ -133,6 +139,7 @@ module EX_MEM_Register_tb;
         EX_csr_write_enable = 1'b1;
         EX_opcode                  = 7'b0000011;      // LOAD opcode
         EX_funct3                  = 3'b010;          // LW
+        EX_rd                      = 5'b01111;
         EX_read_data2              = 32'h0000_0000;   // no RD2
         EX_imm                     = 32'h0000_0018;   // offset 24
         EX_csr_read_data           = 32'h0000_0000;   // no CSR
@@ -140,15 +147,15 @@ module EX_MEM_Register_tb;
         $display("Test 3-1: new input now(should be same)");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
         $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
-        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
 
         @(posedge clk); #1;
         $display("Test 3-2: Test 3-1 input should be output now \n");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
         $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
-        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
 
         flush = 1'b1; #10;
         flush = 1'b0;
@@ -157,8 +164,8 @@ module EX_MEM_Register_tb;
         $display("Test 4: Flushed (should be NOP and zero)");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
         $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
-        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
 
         EX_pc_plus_4               = 32'h0000_0018;   // (PC+4)
         EX_memory_read             = 1'b0;            // no MEM
@@ -168,6 +175,7 @@ module EX_MEM_Register_tb;
         EX_csr_write_enable = 1'b1;
         EX_opcode                  = 7'b0110011;      // R-type
         EX_funct3                  = 3'b000;          // ADD
+        EX_rd                      = 5'b010011;
         EX_read_data2              = 32'h0000_0006;   // (dont-care)
         EX_imm                     = 32'h0000_0000;
         EX_csr_read_data           = 32'h1234_5678;   // dummy CSR test value for pipeline
@@ -175,14 +183,14 @@ module EX_MEM_Register_tb;
         $display("Test 5-1: Input begin (should be same)");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
         $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
-        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
         #10;
         $display("Test 5-2: Test 5-1's input should be output now");
         $display("|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |");
         $display("|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", MEM_pc_plus_4, MEM_memory_read, MEM_memory_write, MEM_register_write_enable, MEM_csr_write_enable, MEM_register_file_write_data_select, MEM_opcode, MEM_funct3);
-        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h |   %h    |    %h    |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result);
+        $display("| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |");
+        $display("|   %h   |  %h |   %h    |    %h    |  %b  |\n", MEM_read_data2, MEM_imm, MEM_csr_read_data, MEM_alu_result, MEM_rd);
 
         $display("\n====================  EX_MEM Register Test END  ====================");
 

--- a/RV32I/testbenches/ID_EX_Register_tb.v
+++ b/RV32I/testbenches/ID_EX_Register_tb.v
@@ -23,6 +23,7 @@ module ID_EX_Register_tb;
     reg [6:0] ID_opcode; 
     reg [2:0] ID_funct3;
     reg [6:0] ID_funct7;
+    reg [4:0] ID_rd;
     reg [11:0] ID_raw_imm;
     reg [XLEN-1:0] ID_read_data1;
     reg [XLEN-1:0] ID_read_data2;
@@ -46,6 +47,7 @@ module ID_EX_Register_tb;
     wire [6:0] EX_opcode;
     wire [2:0] EX_funct3;
     wire [6:0] EX_funct7;
+    wire [4:0] EX_rd;
     wire [11:0] EX_raw_imm;
     wire [XLEN-1:0] EX_read_data1;
     wire [XLEN-1:0] EX_read_data2;
@@ -74,6 +76,7 @@ module ID_EX_Register_tb;
         .ID_opcode(ID_opcode), 
         .ID_funct3(ID_funct3),
         .ID_funct7(ID_funct7),
+        .ID_rd(ID_rd),
         .ID_raw_imm(ID_raw_imm),
         .ID_read_data1(ID_read_data1),
         .ID_read_data2(ID_read_data2),
@@ -97,6 +100,7 @@ module ID_EX_Register_tb;
         .EX_opcode(EX_opcode),
         .EX_funct3(EX_funct3),
         .EX_funct7(EX_funct7),
+        .EX_rd(EX_rd),
         .EX_raw_imm(EX_raw_imm),
         .EX_read_data1(EX_read_data1),
         .EX_read_data2(EX_read_data2),
@@ -124,8 +128,8 @@ module ID_EX_Register_tb;
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
         #10;
         
         // Test 1
@@ -146,6 +150,7 @@ module ID_EX_Register_tb;
         ID_opcode = 7'b0011000;
         ID_funct3 = 3'b010;
         ID_funct7 = 7'b0011110;
+        ID_rd = 5'b00110;
         ID_raw_imm = 12'b0;
         ID_read_data1 = 32'hAAAA_AAAA;
         ID_read_data2 = 32'hBBBB_BBBB;
@@ -159,8 +164,8 @@ module ID_EX_Register_tb;
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
         
         // Test 2@(posedge clk); #1;
         @(posedge clk); #1;
@@ -169,8 +174,8 @@ module ID_EX_Register_tb;
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
 
         // Test 3
         @(negedge clk); 
@@ -185,11 +190,12 @@ module ID_EX_Register_tb;
         ID_memory_read                = 1'b0;
         ID_memory_write               = 1'b0;
         ID_register_file_write_data_select = 3'b000; // ALU result
-        ID_register_write_enable = 1'b1;
-        ID_csr_write_enable = 1'b0;
+        ID_register_write_enable      = 1'b1;
+        ID_csr_write_enable           = 1'b0;
         ID_opcode                     = 7'b0110011; // R-type
         ID_funct3                     = 3'b000;     // ADD
         ID_funct7                     = 7'b0000000; 
+        ID_rd                         = 5'b01000;
         ID_raw_imm                    = 12'h000;
         ID_read_data1                 = 32'h0000_0005; 
         ID_read_data2                 = 32'h0000_000A;
@@ -201,8 +207,8 @@ module ID_EX_Register_tb;
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
 
         @(posedge clk); #1;
         $display("Test 3-2: Test 3-1 input should be output now \n");
@@ -210,8 +216,8 @@ module ID_EX_Register_tb;
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
 
         flush = 1'b1; #10;
         flush = 1'b0;
@@ -222,8 +228,8 @@ module ID_EX_Register_tb;
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
 
         ID_pc                         = 32'h1000_1000;
         ID_pc_plus_4                  = 32'h1000_1004;
@@ -241,6 +247,7 @@ module ID_EX_Register_tb;
         ID_opcode                     = 7'b0000011; // I-type LOAD
         ID_funct3                     = 3'b010;     // LW
         ID_funct7                     = 7'b0000000;
+        ID_rd                         = 5'b01111;
         ID_raw_imm                    = 12'h0F0;
         ID_read_data1                 = 32'h0000_0004; 
         ID_read_data2                 = 32'h0000_0000; // unused for load
@@ -252,16 +259,16 @@ module ID_EX_Register_tb;
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
         #10;
         $display("Test 5-2: Test 5-1's input should be output now\n");
         $display("|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |");
         $display("|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", EX_pc, EX_pc_plus_4, EX_branch_estimation, EX_jump, EX_branch, EX_csr_write_enable, EX_register_write_enable, EX_alu_src_A_select, EX_alu_src_B_select);
         $display("| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |");
         $display("|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", EX_memory_read, EX_memory_write, EX_register_file_write_data_select, EX_opcode, EX_funct3, EX_funct7, EX_raw_imm);
-        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |");
-        $display("|   %h   |   %h   |  %b  |  %h  |   %h   |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data);
+        $display("| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |");
+        $display("|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\n", EX_read_data1, EX_read_data2, EX_rs1, EX_imm, EX_csr_read_data, EX_rd);
 
         $display("\n====================  ID_EX Register Test END  ====================");
 

--- a/RV32I/testbenches/MEM_WB_Register_tb.v
+++ b/RV32I/testbenches/MEM_WB_Register_tb.v
@@ -16,6 +16,7 @@ module MEM_WB_Register_tb;
     reg [XLEN-1:0] MEM_alu_result;
     reg MEM_register_write_enable;
     reg MEM_csr_write_enable;
+    reg [4:0] MEM_rd;
 
     // signals from MEM phase
     reg [XLEN-1:0] MEM_register_file_write_data;
@@ -28,6 +29,7 @@ module MEM_WB_Register_tb;
     wire [XLEN-1:0] WB_alu_result;
     wire WB_register_write_enable;
     wire WB_csr_write_enable;
+    wire [4:0] WB_rd;
 
     wire [XLEN-1:0] WB_register_file_write_data;
 
@@ -43,7 +45,8 @@ module MEM_WB_Register_tb;
         .MEM_alu_result(MEM_alu_result),
         .MEM_register_write_enable(MEM_register_write_enable),
         .MEM_csr_write_enable(MEM_csr_write_enable),
-        .MEM_register_file_write_data,
+        .MEM_rd(MEM_rd),
+        .MEM_register_file_write_data(MEM_register_file_write_data),
 
         .WB_pc_plus_4(WB_pc_plus_4),
         .WB_register_file_write_data_select(WB_register_file_write_data_select),
@@ -52,6 +55,7 @@ module MEM_WB_Register_tb;
         .WB_alu_result(WB_alu_result),
         .WB_register_write_enable(WB_register_write_enable),
         .WB_csr_write_enable(WB_csr_write_enable),
+        .WB_rd(WB_rd),
         .WB_register_file_write_data(WB_register_file_write_data)
     );
 
@@ -72,8 +76,8 @@ module MEM_WB_Register_tb;
         $display("Input now");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
         #10;
         
         // Test 1
@@ -85,22 +89,23 @@ module MEM_WB_Register_tb;
         MEM_alu_result                   = 32'h0000_000B;   // ALU result = 11
         MEM_register_write_enable        = 1'b1;            // Register Write Enable
         MEM_csr_write_enable             = 1'b0;
+        MEM_rd                           = 5'b00110;
         MEM_register_file_write_data     = 32'h0000_000A;   // Dummy BERF_WD data value
 
         @(posedge clk); #1;
         $display("Test 1: Previous value should be output now");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
         
         // Test 2@(posedge clk); #1;
         @(posedge clk); #1;
         $display("Test 2: No input(should be same)");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         // Test 3
         @(negedge clk); 
@@ -111,19 +116,20 @@ module MEM_WB_Register_tb;
         MEM_alu_result                   = 32'h1000_0020;   // ALU result = x3 + 32
         MEM_register_write_enable        = 1'b1;
         MEM_csr_write_enable             = 1'b0;
+        MEM_rd                           = 5'b00111;
         MEM_register_file_write_data     = 32'hDEAD_BEEF;   // Dummy BERF_WD data value
         $display("Test 3-1: new input now(should be same)");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         @(posedge clk); #1;
         $display("Test 3-2: Test 3-1 input should be output now \n");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         flush = 1'b1; #10;
         flush = 1'b0;
@@ -132,8 +138,8 @@ module MEM_WB_Register_tb;
         $display("Test 4: Flushed (should be NOP and zero)");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         MEM_pc_plus_4                    = 32'h0000_000C;
         MEM_register_file_write_data_select = 3'b011;       // CSR read → Register File
@@ -142,18 +148,19 @@ module MEM_WB_Register_tb;
         MEM_alu_result                   = 32'h0000_0000;   // no ALU
         MEM_register_write_enable        = 1'b1;            // rd ← CSR
         MEM_csr_write_enable             = 1'b1;            // CSR write enable
+        MEM_rd                           = 5'b10001;
         MEM_register_file_write_data     = 32'hCAFE_BABE;   // Dummy BERF_WD data value
         $display("Test 5-1: Input begin (should be same)");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
         #10;
         $display("Test 5-2: Test 5-1's input should be output now");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
-        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result);
+        $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         $display("\n====================  MEM_WB_Register Test END  ====================");
 

--- a/RV32I/testbenches/results/EX_MEM_Register_result.vvp
+++ b/RV32I/testbenches/results/EX_MEM_Register_result.vvp
@@ -7,39 +7,41 @@
 :vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
 :vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
 :vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
-S_0000022f5f8ba400 .scope module, "EX_MEM_Register_tb" "EX_MEM_Register_tb" 2 3;
+S_000001c78a764060 .scope module, "EX_MEM_Register_tb" "EX_MEM_Register_tb" 2 3;
  .timescale -9 -12;
-P_0000022f5f8c9b20 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
-v0000022f5f9257d0_0 .var "EX_alu_result", 31 0;
-v0000022f5f925690_0 .var "EX_csr_read_data", 31 0;
-v0000022f5f925550_0 .var "EX_csr_write_enable", 0 0;
-v0000022f5f925ff0_0 .var "EX_funct3", 2 0;
-v0000022f5f924c90_0 .var "EX_imm", 31 0;
-v0000022f5f925410_0 .var "EX_memory_read", 0 0;
-v0000022f5f926590_0 .var "EX_memory_write", 0 0;
-v0000022f5f925370_0 .var "EX_opcode", 6 0;
-v0000022f5f925eb0_0 .var "EX_pc_plus_4", 31 0;
-v0000022f5f925190_0 .var "EX_read_data2", 31 0;
-v0000022f5f9255f0_0 .var "EX_register_file_write_data_select", 2 0;
-v0000022f5f926450_0 .var "EX_register_write_enable", 0 0;
-v0000022f5f925870_0 .net "MEM_alu_result", 31 0, v0000022f5f8c0f70_0;  1 drivers
-v0000022f5f9268b0_0 .net "MEM_csr_read_data", 31 0, v0000022f5f8c1010_0;  1 drivers
-v0000022f5f924d30_0 .net "MEM_csr_write_enable", 0 0, v0000022f5f8c11f0_0;  1 drivers
-v0000022f5f925af0_0 .net "MEM_funct3", 2 0, v0000022f5f8c1830_0;  1 drivers
-v0000022f5f9264f0_0 .net "MEM_imm", 31 0, v0000022f5f8c18d0_0;  1 drivers
-v0000022f5f926090_0 .net "MEM_memory_read", 0 0, v0000022f5f8c0e30_0;  1 drivers
-v0000022f5f926630_0 .net "MEM_memory_write", 0 0, v0000022f5f8c15b0_0;  1 drivers
-v0000022f5f926310_0 .net "MEM_opcode", 6 0, v0000022f5f8c1290_0;  1 drivers
-v0000022f5f924dd0_0 .net "MEM_pc_plus_4", 31 0, v0000022f5f8c1330_0;  1 drivers
-v0000022f5f9266d0_0 .net "MEM_read_data2", 31 0, v0000022f5f8c13d0_0;  1 drivers
-v0000022f5f926270_0 .net "MEM_register_file_write_data_select", 2 0, v0000022f5f8c1470_0;  1 drivers
-v0000022f5f926770_0 .net "MEM_register_write_enable", 0 0, v0000022f5f8c1a10_0;  1 drivers
-v0000022f5f924e70_0 .var "clk", 0 0;
-v0000022f5f9259b0_0 .var "flush", 0 0;
-v0000022f5f925230_0 .var "reset", 0 0;
-E_0000022f5f8c9ca0 .event posedge, v0000022f5f8c1510_0;
-E_0000022f5f8c91e0 .event negedge, v0000022f5f8c1510_0;
-S_0000022f5f8c5b20 .scope module, "ex_mem_register" "EX_MEM_Register" 2 40, 3 1 0, S_0000022f5f8ba400;
+P_000001c78a760740 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
+v000001c78a7fc670_0 .var "EX_alu_result", 31 0;
+v000001c78a7fc850_0 .var "EX_csr_read_data", 31 0;
+v000001c78a7fc8f0_0 .var "EX_csr_write_enable", 0 0;
+v000001c78a7fc3f0_0 .var "EX_funct3", 2 0;
+v000001c78a7fc490_0 .var "EX_imm", 31 0;
+v000001c78a7fc530_0 .var "EX_memory_read", 0 0;
+v000001c78a7fc990_0 .var "EX_memory_write", 0 0;
+v000001c78a7fcd50_0 .var "EX_opcode", 6 0;
+v000001c78a7fcdf0_0 .var "EX_pc_plus_4", 31 0;
+v000001c78a7fd220_0 .var "EX_rd", 4 0;
+v000001c78a7fe9e0_0 .var "EX_read_data2", 31 0;
+v000001c78a7fe620_0 .var "EX_register_file_write_data_select", 2 0;
+v000001c78a7fe6c0_0 .var "EX_register_write_enable", 0 0;
+v000001c78a7fe300_0 .net "MEM_alu_result", 31 0, v000001c78a7fd070_0;  1 drivers
+v000001c78a7fe120_0 .net "MEM_csr_read_data", 31 0, v000001c78a7fc2b0_0;  1 drivers
+v000001c78a7fe1c0_0 .net "MEM_csr_write_enable", 0 0, v000001c78a7fcc10_0;  1 drivers
+v000001c78a7fdcc0_0 .net "MEM_funct3", 2 0, v000001c78a7fcf30_0;  1 drivers
+v000001c78a7fd680_0 .net "MEM_imm", 31 0, v000001c78a7fc210_0;  1 drivers
+v000001c78a7fdc20_0 .net "MEM_memory_read", 0 0, v000001c78a7fce90_0;  1 drivers
+v000001c78a7feb20_0 .net "MEM_memory_write", 0 0, v000001c78a7fca30_0;  1 drivers
+v000001c78a7fd540_0 .net "MEM_opcode", 6 0, v000001c78a7fc5d0_0;  1 drivers
+v000001c78a7fd2c0_0 .net "MEM_pc_plus_4", 31 0, v000001c78a7fcb70_0;  1 drivers
+v000001c78a7fea80_0 .net "MEM_rd", 4 0, v000001c78a7fcfd0_0;  1 drivers
+v000001c78a7fd900_0 .net "MEM_read_data2", 31 0, v000001c78a7fc710_0;  1 drivers
+v000001c78a7fe760_0 .net "MEM_register_file_write_data_select", 2 0, v000001c78a7fcad0_0;  1 drivers
+v000001c78a7fd9a0_0 .net "MEM_register_write_enable", 0 0, v000001c78a7fc7b0_0;  1 drivers
+v000001c78a7fda40_0 .var "clk", 0 0;
+v000001c78a7ff020_0 .var "flush", 0 0;
+v000001c78a7fe8a0_0 .var "reset", 0 0;
+E_000001c78a75fe80 .event posedge, v000001c78a7fccb0_0;
+E_000001c78a7604c0 .event negedge, v000001c78a7fccb0_0;
+S_000001c78a764ac0 .scope module, "ex_mem_register" "EX_MEM_Register" 2 42, 3 1 0, S_000001c78a764060;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "reset";
@@ -52,270 +54,285 @@ S_0000022f5f8c5b20 .scope module, "ex_mem_register" "EX_MEM_Register" 2 40, 3 1 
     .port_info 8 /INPUT 1 "EX_csr_write_enable";
     .port_info 9 /INPUT 7 "EX_opcode";
     .port_info 10 /INPUT 3 "EX_funct3";
-    .port_info 11 /INPUT 32 "EX_read_data2";
-    .port_info 12 /INPUT 32 "EX_imm";
-    .port_info 13 /INPUT 32 "EX_csr_read_data";
-    .port_info 14 /INPUT 32 "EX_alu_result";
-    .port_info 15 /OUTPUT 32 "MEM_pc_plus_4";
-    .port_info 16 /OUTPUT 1 "MEM_memory_read";
-    .port_info 17 /OUTPUT 1 "MEM_memory_write";
-    .port_info 18 /OUTPUT 3 "MEM_register_file_write_data_select";
-    .port_info 19 /OUTPUT 1 "MEM_register_write_enable";
-    .port_info 20 /OUTPUT 1 "MEM_csr_write_enable";
-    .port_info 21 /OUTPUT 7 "MEM_opcode";
-    .port_info 22 /OUTPUT 3 "MEM_funct3";
-    .port_info 23 /OUTPUT 32 "MEM_read_data2";
-    .port_info 24 /OUTPUT 32 "MEM_imm";
-    .port_info 25 /OUTPUT 32 "MEM_csr_read_data";
-    .port_info 26 /OUTPUT 32 "MEM_alu_result";
-P_0000022f5f8c9b60 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
-v0000022f5f8c16f0_0 .net "EX_alu_result", 31 0, v0000022f5f9257d0_0;  1 drivers
-v0000022f5f8c0c50_0 .net "EX_csr_read_data", 31 0, v0000022f5f925690_0;  1 drivers
-v0000022f5f8c1790_0 .net "EX_csr_write_enable", 0 0, v0000022f5f925550_0;  1 drivers
-v0000022f5f8c10b0_0 .net "EX_funct3", 2 0, v0000022f5f925ff0_0;  1 drivers
-v0000022f5f8c1ab0_0 .net "EX_imm", 31 0, v0000022f5f924c90_0;  1 drivers
-v0000022f5f8c0ed0_0 .net "EX_memory_read", 0 0, v0000022f5f925410_0;  1 drivers
-v0000022f5f8c0d90_0 .net "EX_memory_write", 0 0, v0000022f5f926590_0;  1 drivers
-v0000022f5f8c1b50_0 .net "EX_opcode", 6 0, v0000022f5f925370_0;  1 drivers
-v0000022f5f8c0cf0_0 .net "EX_pc_plus_4", 31 0, v0000022f5f925eb0_0;  1 drivers
-v0000022f5f8c1150_0 .net "EX_read_data2", 31 0, v0000022f5f925190_0;  1 drivers
-v0000022f5f8c1970_0 .net "EX_register_file_write_data_select", 2 0, v0000022f5f9255f0_0;  1 drivers
-v0000022f5f8c1650_0 .net "EX_register_write_enable", 0 0, v0000022f5f926450_0;  1 drivers
-v0000022f5f8c0f70_0 .var "MEM_alu_result", 31 0;
-v0000022f5f8c1010_0 .var "MEM_csr_read_data", 31 0;
-v0000022f5f8c11f0_0 .var "MEM_csr_write_enable", 0 0;
-v0000022f5f8c1830_0 .var "MEM_funct3", 2 0;
-v0000022f5f8c18d0_0 .var "MEM_imm", 31 0;
-v0000022f5f8c0e30_0 .var "MEM_memory_read", 0 0;
-v0000022f5f8c15b0_0 .var "MEM_memory_write", 0 0;
-v0000022f5f8c1290_0 .var "MEM_opcode", 6 0;
-v0000022f5f8c1330_0 .var "MEM_pc_plus_4", 31 0;
-v0000022f5f8c13d0_0 .var "MEM_read_data2", 31 0;
-v0000022f5f8c1470_0 .var "MEM_register_file_write_data_select", 2 0;
-v0000022f5f8c1a10_0 .var "MEM_register_write_enable", 0 0;
-v0000022f5f8c1510_0 .net "clk", 0 0, v0000022f5f924e70_0;  1 drivers
-v0000022f5f925e10_0 .net "flush", 0 0, v0000022f5f9259b0_0;  1 drivers
-v0000022f5f925910_0 .net "reset", 0 0, v0000022f5f925230_0;  1 drivers
-E_0000022f5f8c9360 .event posedge, v0000022f5f925910_0, v0000022f5f8c1510_0;
-    .scope S_0000022f5f8c5b20;
+    .port_info 11 /INPUT 5 "EX_rd";
+    .port_info 12 /INPUT 32 "EX_read_data2";
+    .port_info 13 /INPUT 32 "EX_imm";
+    .port_info 14 /INPUT 32 "EX_csr_read_data";
+    .port_info 15 /INPUT 32 "EX_alu_result";
+    .port_info 16 /OUTPUT 32 "MEM_pc_plus_4";
+    .port_info 17 /OUTPUT 1 "MEM_memory_read";
+    .port_info 18 /OUTPUT 1 "MEM_memory_write";
+    .port_info 19 /OUTPUT 3 "MEM_register_file_write_data_select";
+    .port_info 20 /OUTPUT 1 "MEM_register_write_enable";
+    .port_info 21 /OUTPUT 1 "MEM_csr_write_enable";
+    .port_info 22 /OUTPUT 7 "MEM_opcode";
+    .port_info 23 /OUTPUT 3 "MEM_funct3";
+    .port_info 24 /OUTPUT 5 "MEM_rd";
+    .port_info 25 /OUTPUT 32 "MEM_read_data2";
+    .port_info 26 /OUTPUT 32 "MEM_imm";
+    .port_info 27 /OUTPUT 32 "MEM_csr_read_data";
+    .port_info 28 /OUTPUT 32 "MEM_alu_result";
+P_000001c78a7605c0 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
+v000001c78a762b50_0 .net "EX_alu_result", 31 0, v000001c78a7fc670_0;  1 drivers
+v000001c78a716fa0_0 .net "EX_csr_read_data", 31 0, v000001c78a7fc850_0;  1 drivers
+v000001c78a76b540_0 .net "EX_csr_write_enable", 0 0, v000001c78a7fc8f0_0;  1 drivers
+v000001c78a79cc70_0 .net "EX_funct3", 2 0, v000001c78a7fc3f0_0;  1 drivers
+v000001c78a7964a0_0 .net "EX_imm", 31 0, v000001c78a7fc490_0;  1 drivers
+v000001c78a71bee0_0 .net "EX_memory_read", 0 0, v000001c78a7fc530_0;  1 drivers
+v000001c78a764c50_0 .net "EX_memory_write", 0 0, v000001c78a7fc990_0;  1 drivers
+v000001c78a71bc80_0 .net "EX_opcode", 6 0, v000001c78a7fcd50_0;  1 drivers
+v000001c78a75de80_0 .net "EX_pc_plus_4", 31 0, v000001c78a7fcdf0_0;  1 drivers
+v000001c78a75df20_0 .net "EX_rd", 4 0, v000001c78a7fd220_0;  1 drivers
+v000001c78a75dfc0_0 .net "EX_read_data2", 31 0, v000001c78a7fe9e0_0;  1 drivers
+v000001c78a75e060_0 .net "EX_register_file_write_data_select", 2 0, v000001c78a7fe620_0;  1 drivers
+v000001c78a75ca40_0 .net "EX_register_write_enable", 0 0, v000001c78a7fe6c0_0;  1 drivers
+v000001c78a7fd070_0 .var "MEM_alu_result", 31 0;
+v000001c78a7fc2b0_0 .var "MEM_csr_read_data", 31 0;
+v000001c78a7fcc10_0 .var "MEM_csr_write_enable", 0 0;
+v000001c78a7fcf30_0 .var "MEM_funct3", 2 0;
+v000001c78a7fc210_0 .var "MEM_imm", 31 0;
+v000001c78a7fce90_0 .var "MEM_memory_read", 0 0;
+v000001c78a7fca30_0 .var "MEM_memory_write", 0 0;
+v000001c78a7fc5d0_0 .var "MEM_opcode", 6 0;
+v000001c78a7fcb70_0 .var "MEM_pc_plus_4", 31 0;
+v000001c78a7fcfd0_0 .var "MEM_rd", 4 0;
+v000001c78a7fc710_0 .var "MEM_read_data2", 31 0;
+v000001c78a7fcad0_0 .var "MEM_register_file_write_data_select", 2 0;
+v000001c78a7fc7b0_0 .var "MEM_register_write_enable", 0 0;
+v000001c78a7fccb0_0 .net "clk", 0 0, v000001c78a7fda40_0;  1 drivers
+v000001c78a7fc170_0 .net "flush", 0 0, v000001c78a7ff020_0;  1 drivers
+v000001c78a7fc350_0 .net "reset", 0 0, v000001c78a7fe8a0_0;  1 drivers
+E_000001c78a760300 .event posedge, v000001c78a7fc350_0, v000001c78a7fccb0_0;
+    .scope S_000001c78a764ac0;
 T_0 ;
-    %wait E_0000022f5f8c9360;
-    %load/vec4 v0000022f5f925910_0;
+    %wait E_000001c78a760300;
+    %load/vec4 v000001c78a7fc350_0;
     %flag_set/vec4 8;
     %jmp/1 T_0.2, 8;
-    %load/vec4 v0000022f5f925e10_0;
+    %load/vec4 v000001c78a7fc170_0;
     %flag_set/vec4 9;
     %flag_or 8, 9;
 T_0.2;
     %jmp/0xz  T_0.0, 8;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022f5f8c1330_0, 0;
+    %assign/vec4 v000001c78a7fcb70_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000022f5f8c0e30_0, 0;
+    %assign/vec4 v000001c78a7fce90_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000022f5f8c15b0_0, 0;
+    %assign/vec4 v000001c78a7fca30_0, 0;
     %pushi/vec4 0, 0, 3;
-    %assign/vec4 v0000022f5f8c1470_0, 0;
+    %assign/vec4 v000001c78a7fcad0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000022f5f8c1a10_0, 0;
+    %assign/vec4 v000001c78a7fc7b0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000022f5f8c11f0_0, 0;
+    %assign/vec4 v000001c78a7fcc10_0, 0;
     %pushi/vec4 0, 0, 7;
-    %assign/vec4 v0000022f5f8c1290_0, 0;
+    %assign/vec4 v000001c78a7fc5d0_0, 0;
     %pushi/vec4 0, 0, 3;
-    %assign/vec4 v0000022f5f8c1830_0, 0;
+    %assign/vec4 v000001c78a7fcf30_0, 0;
+    %pushi/vec4 0, 0, 5;
+    %assign/vec4 v000001c78a7fcfd0_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022f5f8c13d0_0, 0;
+    %assign/vec4 v000001c78a7fc710_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022f5f8c18d0_0, 0;
+    %assign/vec4 v000001c78a7fc210_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022f5f8c1010_0, 0;
+    %assign/vec4 v000001c78a7fc2b0_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022f5f8c0f70_0, 0;
+    %assign/vec4 v000001c78a7fd070_0, 0;
     %jmp T_0.1;
 T_0.0 ;
-    %load/vec4 v0000022f5f8c0cf0_0;
-    %assign/vec4 v0000022f5f8c1330_0, 0;
-    %load/vec4 v0000022f5f8c0ed0_0;
-    %assign/vec4 v0000022f5f8c0e30_0, 0;
-    %load/vec4 v0000022f5f8c0d90_0;
-    %assign/vec4 v0000022f5f8c15b0_0, 0;
-    %load/vec4 v0000022f5f8c1970_0;
-    %assign/vec4 v0000022f5f8c1470_0, 0;
-    %load/vec4 v0000022f5f8c1650_0;
-    %assign/vec4 v0000022f5f8c1a10_0, 0;
-    %load/vec4 v0000022f5f8c1790_0;
-    %assign/vec4 v0000022f5f8c11f0_0, 0;
-    %load/vec4 v0000022f5f8c1b50_0;
-    %assign/vec4 v0000022f5f8c1290_0, 0;
-    %load/vec4 v0000022f5f8c10b0_0;
-    %assign/vec4 v0000022f5f8c1830_0, 0;
-    %load/vec4 v0000022f5f8c1150_0;
-    %assign/vec4 v0000022f5f8c13d0_0, 0;
-    %load/vec4 v0000022f5f8c1ab0_0;
-    %assign/vec4 v0000022f5f8c18d0_0, 0;
-    %load/vec4 v0000022f5f8c0c50_0;
-    %assign/vec4 v0000022f5f8c1010_0, 0;
+    %load/vec4 v000001c78a75de80_0;
+    %assign/vec4 v000001c78a7fcb70_0, 0;
+    %load/vec4 v000001c78a71bee0_0;
+    %assign/vec4 v000001c78a7fce90_0, 0;
+    %load/vec4 v000001c78a764c50_0;
+    %assign/vec4 v000001c78a7fca30_0, 0;
+    %load/vec4 v000001c78a75e060_0;
+    %assign/vec4 v000001c78a7fcad0_0, 0;
+    %load/vec4 v000001c78a75ca40_0;
+    %assign/vec4 v000001c78a7fc7b0_0, 0;
+    %load/vec4 v000001c78a76b540_0;
+    %assign/vec4 v000001c78a7fcc10_0, 0;
+    %load/vec4 v000001c78a71bc80_0;
+    %assign/vec4 v000001c78a7fc5d0_0, 0;
+    %load/vec4 v000001c78a79cc70_0;
+    %assign/vec4 v000001c78a7fcf30_0, 0;
+    %load/vec4 v000001c78a75df20_0;
+    %assign/vec4 v000001c78a7fcfd0_0, 0;
+    %load/vec4 v000001c78a75dfc0_0;
+    %assign/vec4 v000001c78a7fc710_0, 0;
+    %load/vec4 v000001c78a7964a0_0;
+    %assign/vec4 v000001c78a7fc210_0, 0;
+    %load/vec4 v000001c78a716fa0_0;
+    %assign/vec4 v000001c78a7fc2b0_0, 0;
 T_0.1 ;
     %jmp T_0;
     .thread T_0;
-    .scope S_0000022f5f8ba400;
+    .scope S_000001c78a764060;
 T_1 ;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f924e70_0, 0, 1;
+    %store/vec4 v000001c78a7fda40_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f925230_0, 0, 1;
+    %store/vec4 v000001c78a7fe8a0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f9259b0_0, 0, 1;
+    %store/vec4 v000001c78a7ff020_0, 0, 1;
     %end;
     .thread T_1;
-    .scope S_0000022f5f8ba400;
+    .scope S_000001c78a764060;
 T_2 ;
     %delay 5000, 0;
-    %load/vec4 v0000022f5f924e70_0;
+    %load/vec4 v000001c78a7fda40_0;
     %inv;
-    %store/vec4 v0000022f5f924e70_0, 0, 1;
+    %store/vec4 v000001c78a7fda40_0, 0, 1;
     %jmp T_2;
     .thread T_2;
-    .scope S_0000022f5f8ba400;
+    .scope S_000001c78a764060;
 T_3 ;
-    %vpi_call 2 79 "$dumpfile", "testbenches/results/waveforms/EX_MEM_Register_tb_result.vcd" {0 0 0};
-    %vpi_call 2 80 "$dumpvars", 32'sb00000000000000000000000000000000, S_0000022f5f8c5b20 {0 0 0};
-    %vpi_call 2 83 "$display", "==================== EX_MEM Register Test START ====================\012" {0 0 0};
+    %vpi_call 2 83 "$dumpfile", "testbenches/results/waveforms/EX_MEM_Register_tb_result.vcd" {0 0 0};
+    %vpi_call 2 84 "$dumpvars", 32'sb00000000000000000000000000000000, S_000001c78a764ac0 {0 0 0};
+    %vpi_call 2 87 "$display", "==================== EX_MEM Register Test START ====================\012" {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f925230_0, 0, 1;
+    %store/vec4 v000001c78a7fe8a0_0, 0, 1;
     %delay 30000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f925230_0, 0, 1;
-    %wait E_0000022f5f8c9ca0;
-    %vpi_call 2 90 "$display", "Input now" {0 0 0};
-    %vpi_call 2 91 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 92 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 93 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 94 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
+    %store/vec4 v000001c78a7fe8a0_0, 0, 1;
+    %wait E_000001c78a75fe80;
+    %vpi_call 2 94 "$display", "Input now" {0 0 0};
+    %vpi_call 2 95 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
+    %vpi_call 2 96 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v000001c78a7fd2c0_0, v000001c78a7fdc20_0, v000001c78a7feb20_0, v000001c78a7fd9a0_0, v000001c78a7fe1c0_0, v000001c78a7fe760_0, v000001c78a7fd540_0, v000001c78a7fdcc0_0 {0 0 0};
+    %vpi_call 2 97 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 98 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
     %delay 10000, 0;
-    %wait E_0000022f5f8c91e0;
+    %wait E_000001c78a7604c0;
     %pushi/vec4 8, 0, 32;
-    %store/vec4 v0000022f5f925eb0_0, 0, 32;
+    %store/vec4 v000001c78a7fcdf0_0, 0, 32;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f925410_0, 0, 1;
+    %store/vec4 v000001c78a7fc530_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f926590_0, 0, 1;
+    %store/vec4 v000001c78a7fc990_0, 0, 1;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v0000022f5f9255f0_0, 0, 3;
+    %store/vec4 v000001c78a7fe620_0, 0, 3;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f926450_0, 0, 1;
+    %store/vec4 v000001c78a7fe6c0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f925550_0, 0, 1;
+    %store/vec4 v000001c78a7fc8f0_0, 0, 1;
     %pushi/vec4 35, 0, 7;
-    %store/vec4 v0000022f5f925370_0, 0, 7;
+    %store/vec4 v000001c78a7fcd50_0, 0, 7;
     %pushi/vec4 2, 0, 3;
-    %store/vec4 v0000022f5f925ff0_0, 0, 3;
+    %store/vec4 v000001c78a7fc3f0_0, 0, 3;
+    %pushi/vec4 12, 0, 5;
+    %store/vec4 v000001c78a7fd220_0, 0, 5;
     %pushi/vec4 3735928559, 0, 32;
-    %store/vec4 v0000022f5f925190_0, 0, 32;
+    %store/vec4 v000001c78a7fe9e0_0, 0, 32;
     %pushi/vec4 16, 0, 32;
-    %store/vec4 v0000022f5f924c90_0, 0, 32;
+    %store/vec4 v000001c78a7fc490_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022f5f925690_0, 0, 32;
+    %store/vec4 v000001c78a7fc850_0, 0, 32;
     %pushi/vec4 268435520, 0, 32;
-    %store/vec4 v0000022f5f9257d0_0, 0, 32;
-    %wait E_0000022f5f8c9ca0;
+    %store/vec4 v000001c78a7fc670_0, 0, 32;
+    %wait E_000001c78a75fe80;
     %delay 1000, 0;
-    %vpi_call 2 113 "$display", "Test 1: Previous value should be output now" {0 0 0};
-    %vpi_call 2 114 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 115 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 116 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
-    %wait E_0000022f5f8c9ca0;
+    %vpi_call 2 118 "$display", "Test 1: Previous value should be output now" {0 0 0};
+    %vpi_call 2 119 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
+    %vpi_call 2 120 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 121 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
+    %vpi_call 2 122 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0 {0 0 0};
+    %wait E_000001c78a75fe80;
     %delay 1000, 0;
-    %vpi_call 2 120 "$display", "Test 2: No input(should be same)" {0 0 0};
-    %vpi_call 2 121 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 122 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 123 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 124 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
-    %wait E_0000022f5f8c91e0;
+    %vpi_call 2 126 "$display", "Test 2: No input(should be same)" {0 0 0};
+    %vpi_call 2 127 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
+    %vpi_call 2 128 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v000001c78a7fd2c0_0, v000001c78a7fdc20_0, v000001c78a7feb20_0, v000001c78a7fd9a0_0, v000001c78a7fe1c0_0, v000001c78a7fe760_0, v000001c78a7fd540_0, v000001c78a7fdcc0_0 {0 0 0};
+    %vpi_call 2 129 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 130 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
+    %wait E_000001c78a7604c0;
     %pushi/vec4 16, 0, 32;
-    %store/vec4 v0000022f5f925eb0_0, 0, 32;
+    %store/vec4 v000001c78a7fcdf0_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f925410_0, 0, 1;
+    %store/vec4 v000001c78a7fc530_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f926590_0, 0, 1;
+    %store/vec4 v000001c78a7fc990_0, 0, 1;
     %pushi/vec4 1, 0, 3;
-    %store/vec4 v0000022f5f9255f0_0, 0, 3;
+    %store/vec4 v000001c78a7fe620_0, 0, 3;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f926450_0, 0, 1;
+    %store/vec4 v000001c78a7fe6c0_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f925550_0, 0, 1;
+    %store/vec4 v000001c78a7fc8f0_0, 0, 1;
     %pushi/vec4 3, 0, 7;
-    %store/vec4 v0000022f5f925370_0, 0, 7;
+    %store/vec4 v000001c78a7fcd50_0, 0, 7;
     %pushi/vec4 2, 0, 3;
-    %store/vec4 v0000022f5f925ff0_0, 0, 3;
+    %store/vec4 v000001c78a7fc3f0_0, 0, 3;
+    %pushi/vec4 15, 0, 5;
+    %store/vec4 v000001c78a7fd220_0, 0, 5;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022f5f925190_0, 0, 32;
+    %store/vec4 v000001c78a7fe9e0_0, 0, 32;
     %pushi/vec4 24, 0, 32;
-    %store/vec4 v0000022f5f924c90_0, 0, 32;
+    %store/vec4 v000001c78a7fc490_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022f5f925690_0, 0, 32;
+    %store/vec4 v000001c78a7fc850_0, 0, 32;
     %pushi/vec4 536870960, 0, 32;
-    %store/vec4 v0000022f5f9257d0_0, 0, 32;
-    %vpi_call 2 140 "$display", "Test 3-1: new input now(should be same)" {0 0 0};
-    %vpi_call 2 141 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 142 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 143 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 144 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
-    %wait E_0000022f5f8c9ca0;
-    %delay 1000, 0;
-    %vpi_call 2 147 "$display", "Test 3-2: Test 3-1 input should be output now \012" {0 0 0};
+    %store/vec4 v000001c78a7fc670_0, 0, 32;
+    %vpi_call 2 147 "$display", "Test 3-1: new input now(should be same)" {0 0 0};
     %vpi_call 2 148 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 149 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 150 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 151 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
+    %vpi_call 2 149 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v000001c78a7fd2c0_0, v000001c78a7fdc20_0, v000001c78a7feb20_0, v000001c78a7fd9a0_0, v000001c78a7fe1c0_0, v000001c78a7fe760_0, v000001c78a7fd540_0, v000001c78a7fdcc0_0 {0 0 0};
+    %vpi_call 2 150 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 151 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
+    %wait E_000001c78a75fe80;
+    %delay 1000, 0;
+    %vpi_call 2 154 "$display", "Test 3-2: Test 3-1 input should be output now \012" {0 0 0};
+    %vpi_call 2 155 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
+    %vpi_call 2 156 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v000001c78a7fd2c0_0, v000001c78a7fdc20_0, v000001c78a7feb20_0, v000001c78a7fd9a0_0, v000001c78a7fe1c0_0, v000001c78a7fe760_0, v000001c78a7fd540_0, v000001c78a7fdcc0_0 {0 0 0};
+    %vpi_call 2 157 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 158 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f9259b0_0, 0, 1;
+    %store/vec4 v000001c78a7ff020_0, 0, 1;
     %delay 10000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f9259b0_0, 0, 1;
-    %vpi_call 2 157 "$display", "Test 4: Flushed (should be NOP and zero)" {0 0 0};
-    %vpi_call 2 158 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 159 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 160 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 161 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
+    %store/vec4 v000001c78a7ff020_0, 0, 1;
+    %vpi_call 2 164 "$display", "Test 4: Flushed (should be NOP and zero)" {0 0 0};
+    %vpi_call 2 165 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
+    %vpi_call 2 166 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v000001c78a7fd2c0_0, v000001c78a7fdc20_0, v000001c78a7feb20_0, v000001c78a7fd9a0_0, v000001c78a7fe1c0_0, v000001c78a7fe760_0, v000001c78a7fd540_0, v000001c78a7fdcc0_0 {0 0 0};
+    %vpi_call 2 167 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 168 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
     %pushi/vec4 24, 0, 32;
-    %store/vec4 v0000022f5f925eb0_0, 0, 32;
+    %store/vec4 v000001c78a7fcdf0_0, 0, 32;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f925410_0, 0, 1;
+    %store/vec4 v000001c78a7fc530_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022f5f926590_0, 0, 1;
+    %store/vec4 v000001c78a7fc990_0, 0, 1;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v0000022f5f9255f0_0, 0, 3;
+    %store/vec4 v000001c78a7fe620_0, 0, 3;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f926450_0, 0, 1;
+    %store/vec4 v000001c78a7fe6c0_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022f5f925550_0, 0, 1;
+    %store/vec4 v000001c78a7fc8f0_0, 0, 1;
     %pushi/vec4 51, 0, 7;
-    %store/vec4 v0000022f5f925370_0, 0, 7;
+    %store/vec4 v000001c78a7fcd50_0, 0, 7;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v0000022f5f925ff0_0, 0, 3;
+    %store/vec4 v000001c78a7fc3f0_0, 0, 3;
+    %pushi/vec4 19, 0, 5;
+    %store/vec4 v000001c78a7fd220_0, 0, 5;
     %pushi/vec4 6, 0, 32;
-    %store/vec4 v0000022f5f925190_0, 0, 32;
+    %store/vec4 v000001c78a7fe9e0_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022f5f924c90_0, 0, 32;
+    %store/vec4 v000001c78a7fc490_0, 0, 32;
     %pushi/vec4 305419896, 0, 32;
-    %store/vec4 v0000022f5f925690_0, 0, 32;
+    %store/vec4 v000001c78a7fc850_0, 0, 32;
     %pushi/vec4 11, 0, 32;
-    %store/vec4 v0000022f5f9257d0_0, 0, 32;
-    %vpi_call 2 175 "$display", "Test 5-1: Input begin (should be same)" {0 0 0};
-    %vpi_call 2 176 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 177 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 178 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 179 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
+    %store/vec4 v000001c78a7fc670_0, 0, 32;
+    %vpi_call 2 183 "$display", "Test 5-1: Input begin (should be same)" {0 0 0};
+    %vpi_call 2 184 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
+    %vpi_call 2 185 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v000001c78a7fd2c0_0, v000001c78a7fdc20_0, v000001c78a7feb20_0, v000001c78a7fd9a0_0, v000001c78a7fe1c0_0, v000001c78a7fe760_0, v000001c78a7fd540_0, v000001c78a7fdcc0_0 {0 0 0};
+    %vpi_call 2 186 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 187 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
     %delay 10000, 0;
-    %vpi_call 2 181 "$display", "Test 5-2: Test 5-1's input should be output now" {0 0 0};
-    %vpi_call 2 182 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
-    %vpi_call 2 183 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v0000022f5f924dd0_0, v0000022f5f926090_0, v0000022f5f926630_0, v0000022f5f926770_0, v0000022f5f924d30_0, v0000022f5f926270_0, v0000022f5f926310_0, v0000022f5f925af0_0 {0 0 0};
-    %vpi_call 2 184 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 185 "$display", "|   %h   |  %h |   %h    |    %h    |\012", v0000022f5f9266d0_0, v0000022f5f9264f0_0, v0000022f5f9268b0_0, v0000022f5f925870_0 {0 0 0};
-    %vpi_call 2 187 "$display", "\012====================  EX_MEM Register Test END  ====================" {0 0 0};
-    %vpi_call 2 189 "$stop" {0 0 0};
+    %vpi_call 2 189 "$display", "Test 5-2: Test 5-1's input should be output now" {0 0 0};
+    %vpi_call 2 190 "$display", "|     PC+4     | MEMread | MEMwrite | CSR WE | RegF WE | RF_WD select |  opcode  | funct3 |" {0 0 0};
+    %vpi_call 2 191 "$display", "|   %h   |    %b    |     %b    |    %b   |    %b    |      %b     |  %b  |  %b  |", v000001c78a7fd2c0_0, v000001c78a7fdc20_0, v000001c78a7feb20_0, v000001c78a7fd9a0_0, v000001c78a7fe1c0_0, v000001c78a7fe760_0, v000001c78a7fd540_0, v000001c78a7fdcc0_0 {0 0 0};
+    %vpi_call 2 192 "$display", "| Register RD2 |    imm    | csr_read_data |   ALU result   |  rd  |" {0 0 0};
+    %vpi_call 2 193 "$display", "|   %h   |  %h |   %h    |    %h    |  %b  |\012", v000001c78a7fd900_0, v000001c78a7fd680_0, v000001c78a7fe120_0, v000001c78a7fe300_0, v000001c78a7fea80_0 {0 0 0};
+    %vpi_call 2 195 "$display", "\012====================  EX_MEM Register Test END  ====================" {0 0 0};
+    %vpi_call 2 197 "$stop" {0 0 0};
     %end;
     .thread T_3;
 # The file index is used to find the file name in the following table.

--- a/RV32I/testbenches/results/ID_EX_Register_result.vvp
+++ b/RV32I/testbenches/results/ID_EX_Register_result.vvp
@@ -7,57 +7,59 @@
 :vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
 :vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
 :vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
-S_000001dce7957dd0 .scope module, "ID_EX_Register_tb" "ID_EX_Register_tb" 2 3;
+S_000001f663d49370 .scope module, "ID_EX_Register_tb" "ID_EX_Register_tb" 2 3;
  .timescale -9 -12;
-P_000001dce7904e00 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
-v000001dce7d69d70_0 .net "EX_alu_src_A_select", 1 0, v000001dce7a16fa0_0;  1 drivers
-v000001dce7d69eb0_0 .net "EX_alu_src_B_select", 2 0, v000001dce7976a70_0;  1 drivers
-v000001dce7d6a4f0_0 .net "EX_branch", 0 0, v000001dce7a1bf00_0;  1 drivers
-v000001dce7d6a590_0 .net "EX_branch_estimation", 0 0, v000001dce7920bc0_0;  1 drivers
-v000001dce7d6a630_0 .net "EX_csr_read_data", 31 0, v000001dce7920c60_0;  1 drivers
-v000001dce7d69a50_0 .net "EX_csr_write_enable", 0 0, v000001dce796db10_0;  1 drivers
-v000001dce7d6ac70_0 .net "EX_funct3", 2 0, v000001dce796dbb0_0;  1 drivers
-v000001dce7d69870_0 .net "EX_funct7", 6 0, v000001dce796dc50_0;  1 drivers
-v000001dce7d6a270_0 .net "EX_imm", 31 0, v000001dce796fa40_0;  1 drivers
-v000001dce7d6a810_0 .net "EX_jump", 0 0, v000001dce796fae0_0;  1 drivers
-v000001dce7d69370_0 .net "EX_memory_read", 0 0, v000001dce796fb80_0;  1 drivers
-v000001dce7d6ab30_0 .net "EX_memory_write", 0 0, v000001dce796fc20_0;  1 drivers
-v000001dce7d6af90_0 .net "EX_opcode", 6 0, v000001dce796fcc0_0;  1 drivers
-v000001dce7d6a450_0 .net "EX_pc", 31 0, v000001dce7d68360_0;  1 drivers
-v000001dce7d6aef0_0 .net "EX_pc_plus_4", 31 0, v000001dce7d68f40_0;  1 drivers
-v000001dce7d6a8b0_0 .net "EX_raw_imm", 11 0, v000001dce7d68180_0;  1 drivers
-v000001dce7d6a1d0_0 .net "EX_read_data1", 31 0, v000001dce7d68cc0_0;  1 drivers
-v000001dce7d690f0_0 .net "EX_read_data2", 31 0, v000001dce7d68c20_0;  1 drivers
-v000001dce7d69410_0 .net "EX_register_file_write_data_select", 2 0, v000001dce7d68d60_0;  1 drivers
-v000001dce7d697d0_0 .net "EX_register_write_enable", 0 0, v000001dce7d68fe0_0;  1 drivers
-v000001dce7d69af0_0 .net "EX_rs1", 4 0, v000001dce7d68220_0;  1 drivers
-v000001dce7d6a950_0 .var "ID_alu_src_A_select", 1 0;
-v000001dce7d6abd0_0 .var "ID_alu_src_B_select", 2 0;
-v000001dce7d69190_0 .var "ID_branch", 0 0;
-v000001dce7d69ff0_0 .var "ID_branch_estimation", 0 0;
-v000001dce7d6aa90_0 .var "ID_csr_read_data", 31 0;
-v000001dce7d6a9f0_0 .var "ID_csr_write_enable", 0 0;
-v000001dce7d692d0_0 .var "ID_funct3", 2 0;
-v000001dce7d69f50_0 .var "ID_funct7", 6 0;
-v000001dce7d694b0_0 .var "ID_imm", 31 0;
-v000001dce7d6a310_0 .var "ID_jump", 0 0;
-v000001dce7d6ad10_0 .var "ID_memory_read", 0 0;
-v000001dce7d6a3b0_0 .var "ID_memory_write", 0 0;
-v000001dce7d6adb0_0 .var "ID_opcode", 6 0;
-v000001dce7d6ae50_0 .var "ID_pc", 31 0;
-v000001dce7d6a130_0 .var "ID_pc_plus_4", 31 0;
-v000001dce7d69230_0 .var "ID_raw_imm", 11 0;
-v000001dce7d69550_0 .var "ID_read_data1", 31 0;
-v000001dce7d69730_0 .var "ID_read_data2", 31 0;
-v000001dce7d69690_0 .var "ID_register_file_write_data_select", 2 0;
-v000001dce7d69b90_0 .var "ID_register_write_enable", 0 0;
-v000001dce7d69910_0 .var "ID_rs1", 4 0;
-v000001dce7d699b0_0 .var "clk", 0 0;
-v000001dce7d6bce0_0 .var "flush", 0 0;
-v000001dce7d6c460_0 .var "reset", 0 0;
-E_000001dce79056c0 .event posedge, v000001dce7d69e10_0;
-E_000001dce7905a00 .event negedge, v000001dce7d69e10_0;
-S_000001dce795bdd0 .scope module, "id_ex_register" "ID_EX_Register" 2 56, 3 1 0, S_000001dce7957dd0;
+P_000001f663d4f3d0 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
+v000001f663dbcae0_0 .net "EX_alu_src_A_select", 1 0, v000001f663cff130_0;  1 drivers
+v000001f663dbc680_0 .net "EX_alu_src_B_select", 2 0, v000001f663cff310_0;  1 drivers
+v000001f663dbcc20_0 .net "EX_branch", 0 0, v000001f663cff1d0_0;  1 drivers
+v000001f663dbc4a0_0 .net "EX_branch_estimation", 0 0, v000001f663cff270_0;  1 drivers
+v000001f663dbd1c0_0 .net "EX_csr_read_data", 31 0, v000001f663cfee10_0;  1 drivers
+v000001f663dbc540_0 .net "EX_csr_write_enable", 0 0, v000001f663cfeeb0_0;  1 drivers
+v000001f663dbd620_0 .net "EX_funct3", 2 0, v000001f663cff4f0_0;  1 drivers
+v000001f663dbc5e0_0 .net "EX_funct7", 6 0, v000001f663cfeff0_0;  1 drivers
+v000001f663dbc720_0 .net "EX_imm", 31 0, v000001f663cff590_0;  1 drivers
+v000001f663dbcb80_0 .net "EX_jump", 0 0, v000001f663cff3b0_0;  1 drivers
+v000001f663dbbfa0_0 .net "EX_memory_read", 0 0, v000001f663cffa90_0;  1 drivers
+v000001f663dbc040_0 .net "EX_memory_write", 0 0, v000001f663cffc70_0;  1 drivers
+v000001f663dbd440_0 .net "EX_opcode", 6 0, v000001f663cffb30_0;  1 drivers
+v000001f663dbcd60_0 .net "EX_pc", 31 0, v000001f663cfef50_0;  1 drivers
+v000001f663dbd4e0_0 .net "EX_pc_plus_4", 31 0, v000001f663cffd10_0;  1 drivers
+v000001f663dbd580_0 .net "EX_raw_imm", 11 0, v000001f663cff630_0;  1 drivers
+v000001f663dbd940_0 .net "EX_rd", 4 0, v000001f663cff450_0;  1 drivers
+v000001f663dbd6c0_0 .net "EX_read_data1", 31 0, v000001f663cff950_0;  1 drivers
+v000001f663dbd760_0 .net "EX_read_data2", 31 0, v000001f663cff6d0_0;  1 drivers
+v000001f663dbd800_0 .net "EX_register_file_write_data_select", 2 0, v000001f663cff770_0;  1 drivers
+v000001f663dbc360_0 .net "EX_register_write_enable", 0 0, v000001f663cff810_0;  1 drivers
+v000001f663dbd9e0_0 .net "EX_rs1", 4 0, v000001f663cff8b0_0;  1 drivers
+v000001f663dbda80_0 .var "ID_alu_src_A_select", 1 0;
+v000001f663dbdb20_0 .var "ID_alu_src_B_select", 2 0;
+v000001f663dbdbc0_0 .var "ID_branch", 0 0;
+v000001f663dbbdc0_0 .var "ID_branch_estimation", 0 0;
+v000001f663dbbe60_0 .var "ID_csr_read_data", 31 0;
+v000001f664142100_0 .var "ID_csr_write_enable", 0 0;
+v000001f664143f00_0 .var "ID_funct3", 2 0;
+v000001f664142560_0 .var "ID_funct7", 6 0;
+v000001f664143640_0 .var "ID_imm", 31 0;
+v000001f6641427e0_0 .var "ID_jump", 0 0;
+v000001f664143aa0_0 .var "ID_memory_read", 0 0;
+v000001f664143960_0 .var "ID_memory_write", 0 0;
+v000001f664142240_0 .var "ID_opcode", 6 0;
+v000001f664143500_0 .var "ID_pc", 31 0;
+v000001f664142920_0 .var "ID_pc_plus_4", 31 0;
+v000001f664143a00_0 .var "ID_raw_imm", 11 0;
+v000001f664143b40_0 .var "ID_rd", 4 0;
+v000001f664143e60_0 .var "ID_read_data1", 31 0;
+v000001f6641429c0_0 .var "ID_read_data2", 31 0;
+v000001f6641424c0_0 .var "ID_register_file_write_data_select", 2 0;
+v000001f664143be0_0 .var "ID_register_write_enable", 0 0;
+v000001f664142600_0 .var "ID_rs1", 4 0;
+v000001f664142ba0_0 .var "clk", 0 0;
+v000001f664143c80_0 .var "flush", 0 0;
+v000001f664142a60_0 .var "reset", 0 0;
+E_000001f663d4f410 .event posedge, v000001f663dbc400_0;
+E_000001f663d4f450 .event negedge, v000001f663dbc400_0;
+S_000001f663d01280 .scope module, "id_ex_register" "ID_EX_Register" 2 58, 3 1 0, S_000001f663d49370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "reset";
@@ -77,408 +79,422 @@ S_000001dce795bdd0 .scope module, "id_ex_register" "ID_EX_Register" 2 56, 3 1 0,
     .port_info 15 /INPUT 7 "ID_opcode";
     .port_info 16 /INPUT 3 "ID_funct3";
     .port_info 17 /INPUT 7 "ID_funct7";
-    .port_info 18 /INPUT 12 "ID_raw_imm";
-    .port_info 19 /INPUT 32 "ID_read_data1";
-    .port_info 20 /INPUT 32 "ID_read_data2";
-    .port_info 21 /INPUT 5 "ID_rs1";
-    .port_info 22 /INPUT 32 "ID_imm";
-    .port_info 23 /INPUT 32 "ID_csr_read_data";
-    .port_info 24 /OUTPUT 32 "EX_pc";
-    .port_info 25 /OUTPUT 32 "EX_pc_plus_4";
-    .port_info 26 /OUTPUT 1 "EX_branch_estimation";
-    .port_info 27 /OUTPUT 1 "EX_jump";
-    .port_info 28 /OUTPUT 1 "EX_memory_read";
-    .port_info 29 /OUTPUT 1 "EX_memory_write";
-    .port_info 30 /OUTPUT 3 "EX_register_file_write_data_select";
-    .port_info 31 /OUTPUT 1 "EX_register_write_enable";
-    .port_info 32 /OUTPUT 1 "EX_csr_write_enable";
-    .port_info 33 /OUTPUT 1 "EX_branch";
-    .port_info 34 /OUTPUT 2 "EX_alu_src_A_select";
-    .port_info 35 /OUTPUT 3 "EX_alu_src_B_select";
-    .port_info 36 /OUTPUT 7 "EX_opcode";
-    .port_info 37 /OUTPUT 3 "EX_funct3";
-    .port_info 38 /OUTPUT 7 "EX_funct7";
-    .port_info 39 /OUTPUT 12 "EX_raw_imm";
-    .port_info 40 /OUTPUT 32 "EX_read_data1";
-    .port_info 41 /OUTPUT 32 "EX_read_data2";
-    .port_info 42 /OUTPUT 5 "EX_rs1";
-    .port_info 43 /OUTPUT 32 "EX_imm";
-    .port_info 44 /OUTPUT 32 "EX_csr_read_data";
-P_000001dce7905040 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
-v000001dce7a16fa0_0 .var "EX_alu_src_A_select", 1 0;
-v000001dce7976a70_0 .var "EX_alu_src_B_select", 2 0;
-v000001dce7a1bf00_0 .var "EX_branch", 0 0;
-v000001dce7920bc0_0 .var "EX_branch_estimation", 0 0;
-v000001dce7920c60_0 .var "EX_csr_read_data", 31 0;
-v000001dce796db10_0 .var "EX_csr_write_enable", 0 0;
-v000001dce796dbb0_0 .var "EX_funct3", 2 0;
-v000001dce796dc50_0 .var "EX_funct7", 6 0;
-v000001dce796fa40_0 .var "EX_imm", 31 0;
-v000001dce796fae0_0 .var "EX_jump", 0 0;
-v000001dce796fb80_0 .var "EX_memory_read", 0 0;
-v000001dce796fc20_0 .var "EX_memory_write", 0 0;
-v000001dce796fcc0_0 .var "EX_opcode", 6 0;
-v000001dce7d68360_0 .var "EX_pc", 31 0;
-v000001dce7d68f40_0 .var "EX_pc_plus_4", 31 0;
-v000001dce7d68180_0 .var "EX_raw_imm", 11 0;
-v000001dce7d68cc0_0 .var "EX_read_data1", 31 0;
-v000001dce7d68c20_0 .var "EX_read_data2", 31 0;
-v000001dce7d68d60_0 .var "EX_register_file_write_data_select", 2 0;
-v000001dce7d68fe0_0 .var "EX_register_write_enable", 0 0;
-v000001dce7d68220_0 .var "EX_rs1", 4 0;
-v000001dce7d68ae0_0 .net "ID_alu_src_A_select", 1 0, v000001dce7d6a950_0;  1 drivers
-v000001dce7d685e0_0 .net "ID_alu_src_B_select", 2 0, v000001dce7d6abd0_0;  1 drivers
-v000001dce7d68680_0 .net "ID_branch", 0 0, v000001dce7d69190_0;  1 drivers
-v000001dce7d687c0_0 .net "ID_branch_estimation", 0 0, v000001dce7d69ff0_0;  1 drivers
-v000001dce7d680e0_0 .net "ID_csr_read_data", 31 0, v000001dce7d6aa90_0;  1 drivers
-v000001dce7d68540_0 .net "ID_csr_write_enable", 0 0, v000001dce7d6a9f0_0;  1 drivers
-v000001dce7d682c0_0 .net "ID_funct3", 2 0, v000001dce7d692d0_0;  1 drivers
-v000001dce7d68860_0 .net "ID_funct7", 6 0, v000001dce7d69f50_0;  1 drivers
-v000001dce7d68720_0 .net "ID_imm", 31 0, v000001dce7d694b0_0;  1 drivers
-v000001dce7d68a40_0 .net "ID_jump", 0 0, v000001dce7d6a310_0;  1 drivers
-v000001dce7d68b80_0 .net "ID_memory_read", 0 0, v000001dce7d6ad10_0;  1 drivers
-v000001dce7d68400_0 .net "ID_memory_write", 0 0, v000001dce7d6a3b0_0;  1 drivers
-v000001dce7d684a0_0 .net "ID_opcode", 6 0, v000001dce7d6adb0_0;  1 drivers
-v000001dce7d68900_0 .net "ID_pc", 31 0, v000001dce7d6ae50_0;  1 drivers
-v000001dce7d689a0_0 .net "ID_pc_plus_4", 31 0, v000001dce7d6a130_0;  1 drivers
-v000001dce7d68e00_0 .net "ID_raw_imm", 11 0, v000001dce7d69230_0;  1 drivers
-v000001dce7d68ea0_0 .net "ID_read_data1", 31 0, v000001dce7d69550_0;  1 drivers
-v000001dce7d6a6d0_0 .net "ID_read_data2", 31 0, v000001dce7d69730_0;  1 drivers
-v000001dce7d69c30_0 .net "ID_register_file_write_data_select", 2 0, v000001dce7d69690_0;  1 drivers
-v000001dce7d69cd0_0 .net "ID_register_write_enable", 0 0, v000001dce7d69b90_0;  1 drivers
-v000001dce7d695f0_0 .net "ID_rs1", 4 0, v000001dce7d69910_0;  1 drivers
-v000001dce7d69e10_0 .net "clk", 0 0, v000001dce7d699b0_0;  1 drivers
-v000001dce7d6a090_0 .net "flush", 0 0, v000001dce7d6bce0_0;  1 drivers
-v000001dce7d6a770_0 .net "reset", 0 0, v000001dce7d6c460_0;  1 drivers
-E_000001dce7905700 .event posedge, v000001dce7d6a770_0, v000001dce7d69e10_0;
-    .scope S_000001dce795bdd0;
+    .port_info 18 /INPUT 5 "ID_rd";
+    .port_info 19 /INPUT 12 "ID_raw_imm";
+    .port_info 20 /INPUT 32 "ID_read_data1";
+    .port_info 21 /INPUT 32 "ID_read_data2";
+    .port_info 22 /INPUT 5 "ID_rs1";
+    .port_info 23 /INPUT 32 "ID_imm";
+    .port_info 24 /INPUT 32 "ID_csr_read_data";
+    .port_info 25 /OUTPUT 32 "EX_pc";
+    .port_info 26 /OUTPUT 32 "EX_pc_plus_4";
+    .port_info 27 /OUTPUT 1 "EX_branch_estimation";
+    .port_info 28 /OUTPUT 1 "EX_jump";
+    .port_info 29 /OUTPUT 1 "EX_memory_read";
+    .port_info 30 /OUTPUT 1 "EX_memory_write";
+    .port_info 31 /OUTPUT 3 "EX_register_file_write_data_select";
+    .port_info 32 /OUTPUT 1 "EX_register_write_enable";
+    .port_info 33 /OUTPUT 1 "EX_csr_write_enable";
+    .port_info 34 /OUTPUT 1 "EX_branch";
+    .port_info 35 /OUTPUT 2 "EX_alu_src_A_select";
+    .port_info 36 /OUTPUT 3 "EX_alu_src_B_select";
+    .port_info 37 /OUTPUT 7 "EX_opcode";
+    .port_info 38 /OUTPUT 3 "EX_funct3";
+    .port_info 39 /OUTPUT 7 "EX_funct7";
+    .port_info 40 /OUTPUT 5 "EX_rd";
+    .port_info 41 /OUTPUT 12 "EX_raw_imm";
+    .port_info 42 /OUTPUT 32 "EX_read_data1";
+    .port_info 43 /OUTPUT 32 "EX_read_data2";
+    .port_info 44 /OUTPUT 5 "EX_rs1";
+    .port_info 45 /OUTPUT 32 "EX_imm";
+    .port_info 46 /OUTPUT 32 "EX_csr_read_data";
+P_000001f663d4f010 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
+v000001f663cff130_0 .var "EX_alu_src_A_select", 1 0;
+v000001f663cff310_0 .var "EX_alu_src_B_select", 2 0;
+v000001f663cff1d0_0 .var "EX_branch", 0 0;
+v000001f663cff270_0 .var "EX_branch_estimation", 0 0;
+v000001f663cfee10_0 .var "EX_csr_read_data", 31 0;
+v000001f663cfeeb0_0 .var "EX_csr_write_enable", 0 0;
+v000001f663cff4f0_0 .var "EX_funct3", 2 0;
+v000001f663cfeff0_0 .var "EX_funct7", 6 0;
+v000001f663cff590_0 .var "EX_imm", 31 0;
+v000001f663cff3b0_0 .var "EX_jump", 0 0;
+v000001f663cffa90_0 .var "EX_memory_read", 0 0;
+v000001f663cffc70_0 .var "EX_memory_write", 0 0;
+v000001f663cffb30_0 .var "EX_opcode", 6 0;
+v000001f663cfef50_0 .var "EX_pc", 31 0;
+v000001f663cffd10_0 .var "EX_pc_plus_4", 31 0;
+v000001f663cff630_0 .var "EX_raw_imm", 11 0;
+v000001f663cff450_0 .var "EX_rd", 4 0;
+v000001f663cff950_0 .var "EX_read_data1", 31 0;
+v000001f663cff6d0_0 .var "EX_read_data2", 31 0;
+v000001f663cff770_0 .var "EX_register_file_write_data_select", 2 0;
+v000001f663cff810_0 .var "EX_register_write_enable", 0 0;
+v000001f663cff8b0_0 .var "EX_rs1", 4 0;
+v000001f663cff9f0_0 .net "ID_alu_src_A_select", 1 0, v000001f663dbda80_0;  1 drivers
+v000001f663cffbd0_0 .net "ID_alu_src_B_select", 2 0, v000001f663dbdb20_0;  1 drivers
+v000001f663dbc0e0_0 .net "ID_branch", 0 0, v000001f663dbdbc0_0;  1 drivers
+v000001f663dbd300_0 .net "ID_branch_estimation", 0 0, v000001f663dbbdc0_0;  1 drivers
+v000001f663dbc220_0 .net "ID_csr_read_data", 31 0, v000001f663dbbe60_0;  1 drivers
+v000001f663dbc900_0 .net "ID_csr_write_enable", 0 0, v000001f664142100_0;  1 drivers
+v000001f663dbc860_0 .net "ID_funct3", 2 0, v000001f664143f00_0;  1 drivers
+v000001f663dbce00_0 .net "ID_funct7", 6 0, v000001f664142560_0;  1 drivers
+v000001f663dbcea0_0 .net "ID_imm", 31 0, v000001f664143640_0;  1 drivers
+v000001f663dbd8a0_0 .net "ID_jump", 0 0, v000001f6641427e0_0;  1 drivers
+v000001f663dbccc0_0 .net "ID_memory_read", 0 0, v000001f664143aa0_0;  1 drivers
+v000001f663dbc9a0_0 .net "ID_memory_write", 0 0, v000001f664143960_0;  1 drivers
+v000001f663dbca40_0 .net "ID_opcode", 6 0, v000001f664142240_0;  1 drivers
+v000001f663dbbd20_0 .net "ID_pc", 31 0, v000001f664143500_0;  1 drivers
+v000001f663dbbf00_0 .net "ID_pc_plus_4", 31 0, v000001f664142920_0;  1 drivers
+v000001f663dbc2c0_0 .net "ID_raw_imm", 11 0, v000001f664143a00_0;  1 drivers
+v000001f663dbcf40_0 .net "ID_rd", 4 0, v000001f664143b40_0;  1 drivers
+v000001f663dbd260_0 .net "ID_read_data1", 31 0, v000001f664143e60_0;  1 drivers
+v000001f663dbcfe0_0 .net "ID_read_data2", 31 0, v000001f6641429c0_0;  1 drivers
+v000001f663dbc7c0_0 .net "ID_register_file_write_data_select", 2 0, v000001f6641424c0_0;  1 drivers
+v000001f663dbd3a0_0 .net "ID_register_write_enable", 0 0, v000001f664143be0_0;  1 drivers
+v000001f663dbc180_0 .net "ID_rs1", 4 0, v000001f664142600_0;  1 drivers
+v000001f663dbc400_0 .net "clk", 0 0, v000001f664142ba0_0;  1 drivers
+v000001f663dbd080_0 .net "flush", 0 0, v000001f664143c80_0;  1 drivers
+v000001f663dbd120_0 .net "reset", 0 0, v000001f664142a60_0;  1 drivers
+E_000001f663d4f090 .event posedge, v000001f663dbd120_0, v000001f663dbc400_0;
+    .scope S_000001f663d01280;
 T_0 ;
-    %wait E_000001dce7905700;
-    %load/vec4 v000001dce7d6a770_0;
+    %wait E_000001f663d4f090;
+    %load/vec4 v000001f663dbd120_0;
     %flag_set/vec4 8;
     %jmp/1 T_0.2, 8;
-    %load/vec4 v000001dce7d6a090_0;
+    %load/vec4 v000001f663dbd080_0;
     %flag_set/vec4 9;
     %flag_or 8, 9;
 T_0.2;
     %jmp/0xz  T_0.0, 8;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v000001dce7d68360_0, 0;
+    %assign/vec4 v000001f663cfef50_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v000001dce7d68f40_0, 0;
+    %assign/vec4 v000001f663cffd10_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v000001dce7920bc0_0, 0;
+    %assign/vec4 v000001f663cff270_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v000001dce796fae0_0, 0;
+    %assign/vec4 v000001f663cff3b0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v000001dce796fb80_0, 0;
+    %assign/vec4 v000001f663cffa90_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v000001dce796fc20_0, 0;
+    %assign/vec4 v000001f663cffc70_0, 0;
     %pushi/vec4 0, 0, 3;
-    %assign/vec4 v000001dce7d68d60_0, 0;
+    %assign/vec4 v000001f663cff770_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v000001dce7d68fe0_0, 0;
+    %assign/vec4 v000001f663cff810_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v000001dce796db10_0, 0;
+    %assign/vec4 v000001f663cfeeb0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v000001dce7a1bf00_0, 0;
+    %assign/vec4 v000001f663cff1d0_0, 0;
     %pushi/vec4 0, 0, 2;
-    %assign/vec4 v000001dce7a16fa0_0, 0;
+    %assign/vec4 v000001f663cff130_0, 0;
     %pushi/vec4 0, 0, 3;
-    %assign/vec4 v000001dce7976a70_0, 0;
+    %assign/vec4 v000001f663cff310_0, 0;
     %pushi/vec4 0, 0, 7;
-    %assign/vec4 v000001dce796fcc0_0, 0;
+    %assign/vec4 v000001f663cffb30_0, 0;
     %pushi/vec4 0, 0, 3;
-    %assign/vec4 v000001dce796dbb0_0, 0;
+    %assign/vec4 v000001f663cff4f0_0, 0;
     %pushi/vec4 0, 0, 7;
-    %assign/vec4 v000001dce796dc50_0, 0;
-    %pushi/vec4 0, 0, 12;
-    %assign/vec4 v000001dce7d68180_0, 0;
-    %pushi/vec4 0, 0, 32;
-    %assign/vec4 v000001dce7d68cc0_0, 0;
-    %pushi/vec4 0, 0, 32;
-    %assign/vec4 v000001dce7d68c20_0, 0;
+    %assign/vec4 v000001f663cfeff0_0, 0;
     %pushi/vec4 0, 0, 5;
-    %assign/vec4 v000001dce7d68220_0, 0;
+    %assign/vec4 v000001f663cff450_0, 0;
+    %pushi/vec4 0, 0, 12;
+    %assign/vec4 v000001f663cff630_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v000001dce796fa40_0, 0;
+    %assign/vec4 v000001f663cff950_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v000001dce7920c60_0, 0;
+    %assign/vec4 v000001f663cff6d0_0, 0;
+    %pushi/vec4 0, 0, 5;
+    %assign/vec4 v000001f663cff8b0_0, 0;
+    %pushi/vec4 0, 0, 32;
+    %assign/vec4 v000001f663cff590_0, 0;
+    %pushi/vec4 0, 0, 32;
+    %assign/vec4 v000001f663cfee10_0, 0;
     %jmp T_0.1;
 T_0.0 ;
-    %load/vec4 v000001dce7d68900_0;
-    %assign/vec4 v000001dce7d68360_0, 0;
-    %load/vec4 v000001dce7d689a0_0;
-    %assign/vec4 v000001dce7d68f40_0, 0;
-    %load/vec4 v000001dce7d687c0_0;
-    %assign/vec4 v000001dce7920bc0_0, 0;
-    %load/vec4 v000001dce7d68a40_0;
-    %assign/vec4 v000001dce796fae0_0, 0;
-    %load/vec4 v000001dce7d68b80_0;
-    %assign/vec4 v000001dce796fb80_0, 0;
-    %load/vec4 v000001dce7d68400_0;
-    %assign/vec4 v000001dce796fc20_0, 0;
-    %load/vec4 v000001dce7d69c30_0;
-    %assign/vec4 v000001dce7d68d60_0, 0;
-    %load/vec4 v000001dce7d69cd0_0;
-    %assign/vec4 v000001dce7d68fe0_0, 0;
-    %load/vec4 v000001dce7d68540_0;
-    %assign/vec4 v000001dce796db10_0, 0;
-    %load/vec4 v000001dce7d68680_0;
-    %assign/vec4 v000001dce7a1bf00_0, 0;
-    %load/vec4 v000001dce7d68ae0_0;
-    %assign/vec4 v000001dce7a16fa0_0, 0;
-    %load/vec4 v000001dce7d685e0_0;
-    %assign/vec4 v000001dce7976a70_0, 0;
-    %load/vec4 v000001dce7d684a0_0;
-    %assign/vec4 v000001dce796fcc0_0, 0;
-    %load/vec4 v000001dce7d682c0_0;
-    %assign/vec4 v000001dce796dbb0_0, 0;
-    %load/vec4 v000001dce7d68860_0;
-    %assign/vec4 v000001dce796dc50_0, 0;
-    %load/vec4 v000001dce7d68e00_0;
-    %assign/vec4 v000001dce7d68180_0, 0;
-    %load/vec4 v000001dce7d68ea0_0;
-    %assign/vec4 v000001dce7d68cc0_0, 0;
-    %load/vec4 v000001dce7d6a6d0_0;
-    %assign/vec4 v000001dce7d68c20_0, 0;
-    %load/vec4 v000001dce7d695f0_0;
-    %assign/vec4 v000001dce7d68220_0, 0;
-    %load/vec4 v000001dce7d68720_0;
-    %assign/vec4 v000001dce796fa40_0, 0;
-    %load/vec4 v000001dce7d680e0_0;
-    %assign/vec4 v000001dce7920c60_0, 0;
+    %load/vec4 v000001f663dbbd20_0;
+    %assign/vec4 v000001f663cfef50_0, 0;
+    %load/vec4 v000001f663dbbf00_0;
+    %assign/vec4 v000001f663cffd10_0, 0;
+    %load/vec4 v000001f663dbd300_0;
+    %assign/vec4 v000001f663cff270_0, 0;
+    %load/vec4 v000001f663dbd8a0_0;
+    %assign/vec4 v000001f663cff3b0_0, 0;
+    %load/vec4 v000001f663dbccc0_0;
+    %assign/vec4 v000001f663cffa90_0, 0;
+    %load/vec4 v000001f663dbc9a0_0;
+    %assign/vec4 v000001f663cffc70_0, 0;
+    %load/vec4 v000001f663dbc7c0_0;
+    %assign/vec4 v000001f663cff770_0, 0;
+    %load/vec4 v000001f663dbd3a0_0;
+    %assign/vec4 v000001f663cff810_0, 0;
+    %load/vec4 v000001f663dbc900_0;
+    %assign/vec4 v000001f663cfeeb0_0, 0;
+    %load/vec4 v000001f663dbc0e0_0;
+    %assign/vec4 v000001f663cff1d0_0, 0;
+    %load/vec4 v000001f663cff9f0_0;
+    %assign/vec4 v000001f663cff130_0, 0;
+    %load/vec4 v000001f663cffbd0_0;
+    %assign/vec4 v000001f663cff310_0, 0;
+    %load/vec4 v000001f663dbca40_0;
+    %assign/vec4 v000001f663cffb30_0, 0;
+    %load/vec4 v000001f663dbc860_0;
+    %assign/vec4 v000001f663cff4f0_0, 0;
+    %load/vec4 v000001f663dbce00_0;
+    %assign/vec4 v000001f663cfeff0_0, 0;
+    %load/vec4 v000001f663dbcf40_0;
+    %assign/vec4 v000001f663cff450_0, 0;
+    %load/vec4 v000001f663dbc2c0_0;
+    %assign/vec4 v000001f663cff630_0, 0;
+    %load/vec4 v000001f663dbd260_0;
+    %assign/vec4 v000001f663cff950_0, 0;
+    %load/vec4 v000001f663dbcfe0_0;
+    %assign/vec4 v000001f663cff6d0_0, 0;
+    %load/vec4 v000001f663dbc180_0;
+    %assign/vec4 v000001f663cff8b0_0, 0;
+    %load/vec4 v000001f663dbcea0_0;
+    %assign/vec4 v000001f663cff590_0, 0;
+    %load/vec4 v000001f663dbc220_0;
+    %assign/vec4 v000001f663cfee10_0, 0;
 T_0.1 ;
     %jmp T_0;
     .thread T_0;
-    .scope S_000001dce7957dd0;
+    .scope S_000001f663d49370;
 T_1 ;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d699b0_0, 0, 1;
+    %store/vec4 v000001f664142ba0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6c460_0, 0, 1;
+    %store/vec4 v000001f664142a60_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6bce0_0, 0, 1;
+    %store/vec4 v000001f664143c80_0, 0, 1;
     %end;
     .thread T_1;
-    .scope S_000001dce7957dd0;
+    .scope S_000001f663d49370;
 T_2 ;
     %delay 5000, 0;
-    %load/vec4 v000001dce7d699b0_0;
+    %load/vec4 v000001f664142ba0_0;
     %inv;
-    %store/vec4 v000001dce7d699b0_0, 0, 1;
+    %store/vec4 v000001f664142ba0_0, 0, 1;
     %jmp T_2;
     .thread T_2;
-    .scope S_000001dce7957dd0;
+    .scope S_000001f663d49370;
 T_3 ;
-    %vpi_call 2 111 "$dumpfile", "testbenches/results/waveforms/ID_EX_Register_tb_result.vcd" {0 0 0};
-    %vpi_call 2 112 "$dumpvars", 32'sb00000000000000000000000000000000, S_000001dce795bdd0 {0 0 0};
-    %vpi_call 2 115 "$display", "==================== ID_EX Register Test START ====================\012" {0 0 0};
+    %vpi_call 2 115 "$dumpfile", "testbenches/results/waveforms/ID_EX_Register_tb_result.vcd" {0 0 0};
+    %vpi_call 2 116 "$dumpvars", 32'sb00000000000000000000000000000000, S_000001f663d01280 {0 0 0};
+    %vpi_call 2 119 "$display", "==================== ID_EX Register Test START ====================\012" {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d6c460_0, 0, 1;
+    %store/vec4 v000001f664142a60_0, 0, 1;
     %delay 30000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6c460_0, 0, 1;
-    %wait E_000001dce79056c0;
-    %vpi_call 2 122 "$display", "Input now\012" {0 0 0};
-    %vpi_call 2 123 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 124 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 125 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 126 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 127 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 128 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
+    %store/vec4 v000001f664142a60_0, 0, 1;
+    %wait E_000001f663d4f410;
+    %vpi_call 2 126 "$display", "Input now\012" {0 0 0};
+    %vpi_call 2 127 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 128 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 129 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 130 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 131 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 132 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
     %delay 10000, 0;
-    %wait E_000001dce7905a00;
+    %wait E_000001f663d4f450;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d6ae50_0, 0, 32;
+    %store/vec4 v000001f664143500_0, 0, 32;
     %pushi/vec4 4, 0, 32;
-    %store/vec4 v000001dce7d6a130_0, 0, 32;
+    %store/vec4 v000001f664142920_0, 0, 32;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d69ff0_0, 0, 1;
+    %store/vec4 v000001f663dbbdc0_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d6a310_0, 0, 1;
+    %store/vec4 v000001f6641427e0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d69190_0, 0, 1;
+    %store/vec4 v000001f663dbdbc0_0, 0, 1;
     %pushi/vec4 1, 0, 2;
-    %store/vec4 v000001dce7d6a950_0, 0, 2;
+    %store/vec4 v000001f663dbda80_0, 0, 2;
     %pushi/vec4 2, 0, 3;
-    %store/vec4 v000001dce7d6abd0_0, 0, 3;
+    %store/vec4 v000001f663dbdb20_0, 0, 3;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6ad10_0, 0, 1;
+    %store/vec4 v000001f664143aa0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6a3b0_0, 0, 1;
+    %store/vec4 v000001f664143960_0, 0, 1;
     %pushi/vec4 1, 0, 3;
-    %store/vec4 v000001dce7d69690_0, 0, 3;
+    %store/vec4 v000001f6641424c0_0, 0, 3;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d69b90_0, 0, 1;
+    %store/vec4 v000001f664143be0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6a9f0_0, 0, 1;
+    %store/vec4 v000001f664142100_0, 0, 1;
     %pushi/vec4 24, 0, 7;
-    %store/vec4 v000001dce7d6adb0_0, 0, 7;
+    %store/vec4 v000001f664142240_0, 0, 7;
     %pushi/vec4 2, 0, 3;
-    %store/vec4 v000001dce7d692d0_0, 0, 3;
+    %store/vec4 v000001f664143f00_0, 0, 3;
     %pushi/vec4 30, 0, 7;
-    %store/vec4 v000001dce7d69f50_0, 0, 7;
+    %store/vec4 v000001f664142560_0, 0, 7;
+    %pushi/vec4 6, 0, 5;
+    %store/vec4 v000001f664143b40_0, 0, 5;
     %pushi/vec4 0, 0, 12;
-    %store/vec4 v000001dce7d69230_0, 0, 12;
+    %store/vec4 v000001f664143a00_0, 0, 12;
     %pushi/vec4 2863311530, 0, 32;
-    %store/vec4 v000001dce7d69550_0, 0, 32;
+    %store/vec4 v000001f664143e60_0, 0, 32;
     %pushi/vec4 3149642683, 0, 32;
-    %store/vec4 v000001dce7d69730_0, 0, 32;
+    %store/vec4 v000001f6641429c0_0, 0, 32;
     %pushi/vec4 12, 0, 5;
-    %store/vec4 v000001dce7d69910_0, 0, 5;
+    %store/vec4 v000001f664142600_0, 0, 5;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d694b0_0, 0, 32;
+    %store/vec4 v000001f664143640_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d6aa90_0, 0, 32;
-    %wait E_000001dce79056c0;
+    %store/vec4 v000001f663dbbe60_0, 0, 32;
+    %wait E_000001f663d4f410;
     %delay 1000, 0;
-    %vpi_call 2 157 "$display", "Test 1: Previous value should be output now\012" {0 0 0};
-    %vpi_call 2 158 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 159 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 160 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 161 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 162 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 163 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
-    %wait E_000001dce79056c0;
+    %vpi_call 2 162 "$display", "Test 1: Previous value should be output now\012" {0 0 0};
+    %vpi_call 2 163 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 164 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 165 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 166 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 167 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 168 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
+    %wait E_000001f663d4f410;
     %delay 1000, 0;
-    %vpi_call 2 167 "$display", "Test 2: No input(should be same)\012" {0 0 0};
-    %vpi_call 2 168 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 169 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 170 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 171 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 172 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 173 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
-    %wait E_000001dce7905a00;
+    %vpi_call 2 172 "$display", "Test 2: No input(should be same)\012" {0 0 0};
+    %vpi_call 2 173 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 174 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 175 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 176 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 177 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 178 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
+    %wait E_000001f663d4f450;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d6ae50_0, 0, 32;
+    %store/vec4 v000001f664143500_0, 0, 32;
     %pushi/vec4 4, 0, 32;
-    %store/vec4 v000001dce7d6a130_0, 0, 32;
+    %store/vec4 v000001f664142920_0, 0, 32;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d69ff0_0, 0, 1;
+    %store/vec4 v000001f663dbbdc0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6a310_0, 0, 1;
+    %store/vec4 v000001f6641427e0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d69190_0, 0, 1;
+    %store/vec4 v000001f663dbdbc0_0, 0, 1;
     %pushi/vec4 0, 0, 2;
-    %store/vec4 v000001dce7d6a950_0, 0, 2;
+    %store/vec4 v000001f663dbda80_0, 0, 2;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v000001dce7d6abd0_0, 0, 3;
+    %store/vec4 v000001f663dbdb20_0, 0, 3;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6ad10_0, 0, 1;
+    %store/vec4 v000001f664143aa0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6a3b0_0, 0, 1;
+    %store/vec4 v000001f664143960_0, 0, 1;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v000001dce7d69690_0, 0, 3;
+    %store/vec4 v000001f6641424c0_0, 0, 3;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d69b90_0, 0, 1;
+    %store/vec4 v000001f664143be0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6a9f0_0, 0, 1;
+    %store/vec4 v000001f664142100_0, 0, 1;
     %pushi/vec4 51, 0, 7;
-    %store/vec4 v000001dce7d6adb0_0, 0, 7;
+    %store/vec4 v000001f664142240_0, 0, 7;
     %pushi/vec4 0, 0, 3;
-    %store/vec4 v000001dce7d692d0_0, 0, 3;
+    %store/vec4 v000001f664143f00_0, 0, 3;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v000001dce7d69f50_0, 0, 7;
+    %store/vec4 v000001f664142560_0, 0, 7;
+    %pushi/vec4 8, 0, 5;
+    %store/vec4 v000001f664143b40_0, 0, 5;
     %pushi/vec4 0, 0, 12;
-    %store/vec4 v000001dce7d69230_0, 0, 12;
+    %store/vec4 v000001f664143a00_0, 0, 12;
     %pushi/vec4 5, 0, 32;
-    %store/vec4 v000001dce7d69550_0, 0, 32;
+    %store/vec4 v000001f664143e60_0, 0, 32;
     %pushi/vec4 10, 0, 32;
-    %store/vec4 v000001dce7d69730_0, 0, 32;
+    %store/vec4 v000001f6641429c0_0, 0, 32;
     %pushi/vec4 5, 0, 5;
-    %store/vec4 v000001dce7d69910_0, 0, 5;
+    %store/vec4 v000001f664142600_0, 0, 5;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d694b0_0, 0, 32;
+    %store/vec4 v000001f664143640_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d6aa90_0, 0, 32;
-    %vpi_call 2 199 "$display", "Test 3-1: new input now(should be same) \012" {0 0 0};
-    %vpi_call 2 200 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 201 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 202 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 203 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 204 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 205 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
-    %wait E_000001dce79056c0;
+    %store/vec4 v000001f663dbbe60_0, 0, 32;
+    %vpi_call 2 205 "$display", "Test 3-1: new input now(should be same) \012" {0 0 0};
+    %vpi_call 2 206 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 207 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 208 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 209 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 210 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 211 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
+    %wait E_000001f663d4f410;
     %delay 1000, 0;
-    %vpi_call 2 208 "$display", "Test 3-2: Test 3-1 input should be output now \012" {0 0 0};
-    %vpi_call 2 209 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 210 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 211 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 212 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 213 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 214 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
+    %vpi_call 2 214 "$display", "Test 3-2: Test 3-1 input should be output now \012" {0 0 0};
+    %vpi_call 2 215 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 216 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 217 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 218 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 219 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 220 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d6bce0_0, 0, 1;
+    %store/vec4 v000001f664143c80_0, 0, 1;
     %delay 10000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6bce0_0, 0, 1;
-    %vpi_call 2 220 "$display", "Test 4: Flushed (should be NOP and zero)\012" {0 0 0};
-    %vpi_call 2 221 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 222 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 223 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 224 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 225 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 226 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
+    %store/vec4 v000001f664143c80_0, 0, 1;
+    %vpi_call 2 226 "$display", "Test 4: Flushed (should be NOP and zero)\012" {0 0 0};
+    %vpi_call 2 227 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 228 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 229 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 230 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 231 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 232 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
     %pushi/vec4 268439552, 0, 32;
-    %store/vec4 v000001dce7d6ae50_0, 0, 32;
+    %store/vec4 v000001f664143500_0, 0, 32;
     %pushi/vec4 268439556, 0, 32;
-    %store/vec4 v000001dce7d6a130_0, 0, 32;
+    %store/vec4 v000001f664142920_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d69ff0_0, 0, 1;
+    %store/vec4 v000001f663dbbdc0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6a310_0, 0, 1;
+    %store/vec4 v000001f6641427e0_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d69190_0, 0, 1;
+    %store/vec4 v000001f663dbdbc0_0, 0, 1;
     %pushi/vec4 0, 0, 2;
-    %store/vec4 v000001dce7d6a950_0, 0, 2;
+    %store/vec4 v000001f663dbda80_0, 0, 2;
     %pushi/vec4 1, 0, 3;
-    %store/vec4 v000001dce7d6abd0_0, 0, 3;
+    %store/vec4 v000001f663dbdb20_0, 0, 3;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d6ad10_0, 0, 1;
+    %store/vec4 v000001f664143aa0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d6a3b0_0, 0, 1;
+    %store/vec4 v000001f664143960_0, 0, 1;
     %pushi/vec4 1, 0, 3;
-    %store/vec4 v000001dce7d69690_0, 0, 3;
+    %store/vec4 v000001f6641424c0_0, 0, 3;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v000001dce7d69b90_0, 0, 1;
+    %store/vec4 v000001f664143be0_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v000001dce7d6a9f0_0, 0, 1;
+    %store/vec4 v000001f664142100_0, 0, 1;
     %pushi/vec4 3, 0, 7;
-    %store/vec4 v000001dce7d6adb0_0, 0, 7;
+    %store/vec4 v000001f664142240_0, 0, 7;
     %pushi/vec4 2, 0, 3;
-    %store/vec4 v000001dce7d692d0_0, 0, 3;
+    %store/vec4 v000001f664143f00_0, 0, 3;
     %pushi/vec4 0, 0, 7;
-    %store/vec4 v000001dce7d69f50_0, 0, 7;
+    %store/vec4 v000001f664142560_0, 0, 7;
+    %pushi/vec4 15, 0, 5;
+    %store/vec4 v000001f664143b40_0, 0, 5;
     %pushi/vec4 240, 0, 12;
-    %store/vec4 v000001dce7d69230_0, 0, 12;
+    %store/vec4 v000001f664143a00_0, 0, 12;
     %pushi/vec4 4, 0, 32;
-    %store/vec4 v000001dce7d69550_0, 0, 32;
+    %store/vec4 v000001f664143e60_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d69730_0, 0, 32;
+    %store/vec4 v000001f6641429c0_0, 0, 32;
     %pushi/vec4 2, 0, 5;
-    %store/vec4 v000001dce7d69910_0, 0, 5;
+    %store/vec4 v000001f664142600_0, 0, 5;
     %pushi/vec4 240, 0, 32;
-    %store/vec4 v000001dce7d694b0_0, 0, 32;
+    %store/vec4 v000001f664143640_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v000001dce7d6aa90_0, 0, 32;
-    %vpi_call 2 250 "$display", "Test 5-1: Input begin (should be same)\012" {0 0 0};
-    %vpi_call 2 251 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 252 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 253 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 254 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 255 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 256 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
+    %store/vec4 v000001f663dbbe60_0, 0, 32;
+    %vpi_call 2 257 "$display", "Test 5-1: Input begin (should be same)\012" {0 0 0};
+    %vpi_call 2 258 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 259 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 260 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 261 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 262 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 263 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
     %delay 10000, 0;
-    %vpi_call 2 258 "$display", "Test 5-2: Test 5-1's input should be output now\012" {0 0 0};
-    %vpi_call 2 259 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
-    %vpi_call 2 260 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001dce7d6a450_0, v000001dce7d6aef0_0, v000001dce7d6a590_0, v000001dce7d6a810_0, v000001dce7d6a4f0_0, v000001dce7d69a50_0, v000001dce7d697d0_0, v000001dce7d69d70_0, v000001dce7d69eb0_0 {0 0 0};
-    %vpi_call 2 261 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
-    %vpi_call 2 262 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001dce7d69370_0, v000001dce7d6ab30_0, v000001dce7d69410_0, v000001dce7d6af90_0, v000001dce7d6ac70_0, v000001dce7d69870_0, v000001dce7d6a8b0_0 {0 0 0};
-    %vpi_call 2 263 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |" {0 0 0};
-    %vpi_call 2 264 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   |\012", v000001dce7d6a1d0_0, v000001dce7d690f0_0, v000001dce7d69af0_0, v000001dce7d6a270_0, v000001dce7d6a630_0 {0 0 0};
-    %vpi_call 2 266 "$display", "\012====================  ID_EX Register Test END  ====================" {0 0 0};
-    %vpi_call 2 268 "$stop" {0 0 0};
+    %vpi_call 2 265 "$display", "Test 5-2: Test 5-1's input should be output now\012" {0 0 0};
+    %vpi_call 2 266 "$display", "|     PC     |     PC+4     |   branch est  | jump | branch | CSR WE | RegF WE | ALUsrcA | ALUsrcB |" {0 0 0};
+    %vpi_call 2 267 "$display", "|  %h  |   %h   |       %b       |   %b  |    %b   |    %b   |    %b    |    %b   |   %b   |", v000001f663dbcd60_0, v000001f663dbd4e0_0, v000001f663dbc4a0_0, v000001f663dbcb80_0, v000001f663dbcc20_0, v000001f663dbc540_0, v000001f663dbc360_0, v000001f663dbcae0_0, v000001f663dbc680_0 {0 0 0};
+    %vpi_call 2 268 "$display", "| MEMread | MEMwrite | RF_WD select |  opcode  | funct3 |  funct7   |   raw_imm   |" {0 0 0};
+    %vpi_call 2 269 "$display", "|    %b    |     %b    |      %b     |  %b |   %b  |  %b  |  %b  |", v000001f663dbbfa0_0, v000001f663dbc040_0, v000001f663dbd800_0, v000001f663dbd440_0, v000001f663dbd620_0, v000001f663dbc5e0_0, v000001f663dbd580_0 {0 0 0};
+    %vpi_call 2 270 "$display", "| Register RD1 | Register RD2 |   rs1   |     imm    | csr_read_data |  rd  |" {0 0 0};
+    %vpi_call 2 271 "$display", "|   %h   |   %h   |  %b  |  %h  |   %h   | %b |\012", v000001f663dbd6c0_0, v000001f663dbd760_0, v000001f663dbd9e0_0, v000001f663dbc720_0, v000001f663dbd1c0_0, v000001f663dbd940_0 {0 0 0};
+    %vpi_call 2 273 "$display", "\012====================  ID_EX Register Test END  ====================" {0 0 0};
+    %vpi_call 2 275 "$stop" {0 0 0};
     %end;
     .thread T_3;
 # The file index is used to find the file name in the following table.

--- a/RV32I/testbenches/results/MEM_WB_Register_result.vvp
+++ b/RV32I/testbenches/results/MEM_WB_Register_result.vvp
@@ -7,31 +7,33 @@
 :vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
 :vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
 :vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
-S_0000022fd97b4b00 .scope module, "MEM_WB_Register_tb" "MEM_WB_Register_tb" 2 3;
+S_0000025acd5ec190 .scope module, "MEM_WB_Register_tb" "MEM_WB_Register_tb" 2 3;
  .timescale -9 -12;
-P_0000022fd98d95e0 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
-v0000022fd983ad40_0 .var "MEM_alu_result", 31 0;
-v0000022fd983a5c0_0 .var "MEM_csr_read_data", 31 0;
-v0000022fd983a660_0 .var "MEM_csr_write_enable", 0 0;
-v0000022fd983ade0_0 .var "MEM_imm", 31 0;
-v0000022fd983b4c0_0 .var "MEM_pc_plus_4", 31 0;
-v0000022fd983af20_0 .var "MEM_register_file_write_data", 31 0;
-v0000022fd983ae80_0 .var "MEM_register_file_write_data_select", 2 0;
-v0000022fd983a980_0 .var "MEM_register_write_enable", 0 0;
-v0000022fd983a700_0 .net "WB_alu_result", 31 0, v0000022fd97e02e0_0;  1 drivers
-v0000022fd983b060_0 .net "WB_csr_read_data", 31 0, v0000022fd97d7690_0;  1 drivers
-v0000022fd983a8e0_0 .net "WB_csr_write_enable", 0 0, v0000022fd97a8bd0_0;  1 drivers
-v0000022fd983a7a0_0 .net "WB_imm", 31 0, v0000022fd97a9fa0_0;  1 drivers
-v0000022fd983b240_0 .net "WB_pc_plus_4", 31 0, v0000022fd983b420_0;  1 drivers
-v0000022fd983b2e0_0 .net "WB_register_file_write_data", 31 0, v0000022fd983b100_0;  1 drivers
-v0000022fd983b380_0 .net "WB_register_file_write_data_select", 2 0, v0000022fd983aca0_0;  1 drivers
-v0000022fd983aa20_0 .net "WB_register_write_enable", 0 0, v0000022fd983ab60_0;  1 drivers
-v0000022fd983aac0_0 .var "clk", 0 0;
-v0000022fd983cbb0_0 .var "flush", 0 0;
-v0000022fd983cf70_0 .var "reset", 0 0;
-E_0000022fd98d97e0 .event posedge, v0000022fd983ac00_0;
-E_0000022fd98d98a0 .event negedge, v0000022fd983ac00_0;
-S_0000022fd97db390 .scope module, "mem_wb_register" "MEM_WB_Register" 2 34, 3 1 0, S_0000022fd97b4b00;
+P_0000025acd617d00 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
+v0000025acd6853c0_0 .var "MEM_alu_result", 31 0;
+v0000025acd685320_0 .var "MEM_csr_read_data", 31 0;
+v0000025acd685820_0 .var "MEM_csr_write_enable", 0 0;
+v0000025acd685460_0 .var "MEM_imm", 31 0;
+v0000025acd684e20_0 .var "MEM_pc_plus_4", 31 0;
+v0000025acd685500_0 .var "MEM_rd", 4 0;
+v0000025acd6856e0_0 .var "MEM_register_file_write_data", 31 0;
+v0000025acd684f60_0 .var "MEM_register_file_write_data_select", 2 0;
+v0000025acd685000_0 .var "MEM_register_write_enable", 0 0;
+v0000025acd685140_0 .net "WB_alu_result", 31 0, v0000025acd5a68d0_0;  1 drivers
+v0000025acd6851e0_0 .net "WB_csr_read_data", 31 0, v0000025acd684c40_0;  1 drivers
+v0000025acd6855a0_0 .net "WB_csr_write_enable", 0 0, v0000025acd684ec0_0;  1 drivers
+v0000025acd685640_0 .net "WB_imm", 31 0, v0000025acd685960_0;  1 drivers
+v0000025acd685780_0 .net "WB_pc_plus_4", 31 0, v0000025acd684ba0_0;  1 drivers
+v0000025acd6861f0_0 .net "WB_rd", 4 0, v0000025acd685280_0;  1 drivers
+v0000025acd687050_0 .net "WB_register_file_write_data", 31 0, v0000025acd685a00_0;  1 drivers
+v0000025acd687870_0 .net "WB_register_file_write_data_select", 2 0, v0000025acd684b00_0;  1 drivers
+v0000025acd685cf0_0 .net "WB_register_write_enable", 0 0, v0000025acd6858c0_0;  1 drivers
+v0000025acd686970_0 .var "clk", 0 0;
+v0000025acd6868d0_0 .var "flush", 0 0;
+v0000025acd6879b0_0 .var "reset", 0 0;
+E_0000025acd617a00 .event posedge, v0000025acd684ce0_0;
+E_0000025acd617580 .event negedge, v0000025acd684ce0_0;
+S_0000025acd5ec320 .scope module, "mem_wb_register" "MEM_WB_Register" 2 36, 3 1 0, S_0000025acd5ec190;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "reset";
@@ -43,218 +45,232 @@ S_0000022fd97db390 .scope module, "mem_wb_register" "MEM_WB_Register" 2 34, 3 1 
     .port_info 7 /INPUT 32 "MEM_alu_result";
     .port_info 8 /INPUT 1 "MEM_register_write_enable";
     .port_info 9 /INPUT 1 "MEM_csr_write_enable";
-    .port_info 10 /INPUT 32 "MEM_register_file_write_data";
-    .port_info 11 /OUTPUT 32 "WB_pc_plus_4";
-    .port_info 12 /OUTPUT 3 "WB_register_file_write_data_select";
-    .port_info 13 /OUTPUT 32 "WB_imm";
-    .port_info 14 /OUTPUT 32 "WB_csr_read_data";
-    .port_info 15 /OUTPUT 32 "WB_alu_result";
-    .port_info 16 /OUTPUT 1 "WB_register_write_enable";
-    .port_info 17 /OUTPUT 1 "WB_csr_write_enable";
-    .port_info 18 /OUTPUT 32 "WB_register_file_write_data";
-P_0000022fd98d9560 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
-v0000022fd97ac470_0 .net "MEM_alu_result", 31 0, v0000022fd983ad40_0;  1 drivers
-v0000022fd98d6fa0_0 .net "MEM_csr_read_data", 31 0, v0000022fd983a5c0_0;  1 drivers
-v0000022fd97b8ff0_0 .net "MEM_csr_write_enable", 0 0, v0000022fd983a660_0;  1 drivers
-v0000022fd97b4c90_0 .net "MEM_imm", 31 0, v0000022fd983ade0_0;  1 drivers
-v0000022fd98dbf10_0 .net "MEM_pc_plus_4", 31 0, v0000022fd983b4c0_0;  1 drivers
-v0000022fd97ae8d0_0 .net "MEM_register_file_write_data", 31 0, v0000022fd983af20_0;  1 drivers
-v0000022fd97e11e0_0 .net "MEM_register_file_write_data_select", 2 0, v0000022fd983ae80_0;  1 drivers
-v0000022fd97da4d0_0 .net "MEM_register_write_enable", 0 0, v0000022fd983a980_0;  1 drivers
-v0000022fd97e02e0_0 .var "WB_alu_result", 31 0;
-v0000022fd97d7690_0 .var "WB_csr_read_data", 31 0;
-v0000022fd97a8bd0_0 .var "WB_csr_write_enable", 0 0;
-v0000022fd97a9fa0_0 .var "WB_imm", 31 0;
-v0000022fd983b420_0 .var "WB_pc_plus_4", 31 0;
-v0000022fd983b100_0 .var "WB_register_file_write_data", 31 0;
-v0000022fd983aca0_0 .var "WB_register_file_write_data_select", 2 0;
-v0000022fd983ab60_0 .var "WB_register_write_enable", 0 0;
-v0000022fd983ac00_0 .net "clk", 0 0, v0000022fd983aac0_0;  1 drivers
-v0000022fd983afc0_0 .net "flush", 0 0, v0000022fd983cbb0_0;  1 drivers
-v0000022fd983b1a0_0 .net "reset", 0 0, v0000022fd983cf70_0;  1 drivers
-E_0000022fd98d9260 .event posedge, v0000022fd983b1a0_0, v0000022fd983ac00_0;
-    .scope S_0000022fd97db390;
+    .port_info 10 /INPUT 5 "MEM_rd";
+    .port_info 11 /INPUT 32 "MEM_register_file_write_data";
+    .port_info 12 /OUTPUT 32 "WB_pc_plus_4";
+    .port_info 13 /OUTPUT 3 "WB_register_file_write_data_select";
+    .port_info 14 /OUTPUT 32 "WB_imm";
+    .port_info 15 /OUTPUT 32 "WB_csr_read_data";
+    .port_info 16 /OUTPUT 32 "WB_alu_result";
+    .port_info 17 /OUTPUT 1 "WB_register_write_enable";
+    .port_info 18 /OUTPUT 1 "WB_csr_write_enable";
+    .port_info 19 /OUTPUT 5 "WB_rd";
+    .port_info 20 /OUTPUT 32 "WB_register_file_write_data";
+P_0000025acd6171c0 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
+v0000025acd5eb2f0_0 .net "MEM_alu_result", 31 0, v0000025acd6853c0_0;  1 drivers
+v0000025acd5e9e60_0 .net "MEM_csr_read_data", 31 0, v0000025acd685320_0;  1 drivers
+v0000025acd5a6fa0_0 .net "MEM_csr_write_enable", 0 0, v0000025acd685820_0;  1 drivers
+v0000025acd5f9060_0 .net "MEM_imm", 31 0, v0000025acd685460_0;  1 drivers
+v0000025acd621320_0 .net "MEM_pc_plus_4", 31 0, v0000025acd684e20_0;  1 drivers
+v0000025acd5f20e0_0 .net "MEM_rd", 4 0, v0000025acd685500_0;  1 drivers
+v0000025acd5f2180_0 .net "MEM_register_file_write_data", 31 0, v0000025acd6856e0_0;  1 drivers
+v0000025acd5f2220_0 .net "MEM_register_file_write_data_select", 2 0, v0000025acd684f60_0;  1 drivers
+v0000025acd5f22c0_0 .net "MEM_register_write_enable", 0 0, v0000025acd685000_0;  1 drivers
+v0000025acd5a68d0_0 .var "WB_alu_result", 31 0;
+v0000025acd684c40_0 .var "WB_csr_read_data", 31 0;
+v0000025acd684ec0_0 .var "WB_csr_write_enable", 0 0;
+v0000025acd685960_0 .var "WB_imm", 31 0;
+v0000025acd684ba0_0 .var "WB_pc_plus_4", 31 0;
+v0000025acd685280_0 .var "WB_rd", 4 0;
+v0000025acd685a00_0 .var "WB_register_file_write_data", 31 0;
+v0000025acd684b00_0 .var "WB_register_file_write_data_select", 2 0;
+v0000025acd6858c0_0 .var "WB_register_write_enable", 0 0;
+v0000025acd684ce0_0 .net "clk", 0 0, v0000025acd686970_0;  1 drivers
+v0000025acd6850a0_0 .net "flush", 0 0, v0000025acd6868d0_0;  1 drivers
+v0000025acd684d80_0 .net "reset", 0 0, v0000025acd6879b0_0;  1 drivers
+E_0000025acd6176c0 .event posedge, v0000025acd684d80_0, v0000025acd684ce0_0;
+    .scope S_0000025acd5ec320;
 T_0 ;
-    %wait E_0000022fd98d9260;
-    %load/vec4 v0000022fd983b1a0_0;
+    %wait E_0000025acd6176c0;
+    %load/vec4 v0000025acd684d80_0;
     %flag_set/vec4 8;
     %jmp/1 T_0.2, 8;
-    %load/vec4 v0000022fd983afc0_0;
+    %load/vec4 v0000025acd6850a0_0;
     %flag_set/vec4 9;
     %flag_or 8, 9;
 T_0.2;
     %jmp/0xz  T_0.0, 8;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022fd983b420_0, 0;
+    %assign/vec4 v0000025acd684ba0_0, 0;
     %pushi/vec4 0, 0, 3;
-    %assign/vec4 v0000022fd983aca0_0, 0;
+    %assign/vec4 v0000025acd684b00_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022fd97a9fa0_0, 0;
+    %assign/vec4 v0000025acd685960_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022fd97d7690_0, 0;
+    %assign/vec4 v0000025acd684c40_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022fd97e02e0_0, 0;
+    %assign/vec4 v0000025acd5a68d0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000022fd983ab60_0, 0;
+    %assign/vec4 v0000025acd6858c0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000022fd97a8bd0_0, 0;
+    %assign/vec4 v0000025acd684ec0_0, 0;
+    %pushi/vec4 0, 0, 5;
+    %assign/vec4 v0000025acd685280_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000022fd983b100_0, 0;
+    %assign/vec4 v0000025acd685a00_0, 0;
     %jmp T_0.1;
 T_0.0 ;
-    %load/vec4 v0000022fd98dbf10_0;
-    %assign/vec4 v0000022fd983b420_0, 0;
-    %load/vec4 v0000022fd97e11e0_0;
-    %assign/vec4 v0000022fd983aca0_0, 0;
-    %load/vec4 v0000022fd97b4c90_0;
-    %assign/vec4 v0000022fd97a9fa0_0, 0;
-    %load/vec4 v0000022fd98d6fa0_0;
-    %assign/vec4 v0000022fd97d7690_0, 0;
-    %load/vec4 v0000022fd97ac470_0;
-    %assign/vec4 v0000022fd97e02e0_0, 0;
-    %load/vec4 v0000022fd97da4d0_0;
-    %assign/vec4 v0000022fd983ab60_0, 0;
-    %load/vec4 v0000022fd97b8ff0_0;
-    %assign/vec4 v0000022fd97a8bd0_0, 0;
-    %load/vec4 v0000022fd97ae8d0_0;
-    %assign/vec4 v0000022fd983b100_0, 0;
+    %load/vec4 v0000025acd621320_0;
+    %assign/vec4 v0000025acd684ba0_0, 0;
+    %load/vec4 v0000025acd5f2220_0;
+    %assign/vec4 v0000025acd684b00_0, 0;
+    %load/vec4 v0000025acd5f9060_0;
+    %assign/vec4 v0000025acd685960_0, 0;
+    %load/vec4 v0000025acd5e9e60_0;
+    %assign/vec4 v0000025acd684c40_0, 0;
+    %load/vec4 v0000025acd5eb2f0_0;
+    %assign/vec4 v0000025acd5a68d0_0, 0;
+    %load/vec4 v0000025acd5f22c0_0;
+    %assign/vec4 v0000025acd6858c0_0, 0;
+    %load/vec4 v0000025acd5a6fa0_0;
+    %assign/vec4 v0000025acd684ec0_0, 0;
+    %load/vec4 v0000025acd5f20e0_0;
+    %assign/vec4 v0000025acd685280_0, 0;
+    %load/vec4 v0000025acd5f2180_0;
+    %assign/vec4 v0000025acd685a00_0, 0;
 T_0.1 ;
     %jmp T_0;
     .thread T_0;
-    .scope S_0000022fd97b4b00;
+    .scope S_0000025acd5ec190;
 T_1 ;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022fd983aac0_0, 0, 1;
+    %store/vec4 v0000025acd686970_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022fd983cf70_0, 0, 1;
+    %store/vec4 v0000025acd6879b0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022fd983cbb0_0, 0, 1;
+    %store/vec4 v0000025acd6868d0_0, 0, 1;
     %end;
     .thread T_1;
-    .scope S_0000022fd97b4b00;
+    .scope S_0000025acd5ec190;
 T_2 ;
     %delay 5000, 0;
-    %load/vec4 v0000022fd983aac0_0;
+    %load/vec4 v0000025acd686970_0;
     %inv;
-    %store/vec4 v0000022fd983aac0_0, 0, 1;
+    %store/vec4 v0000025acd686970_0, 0, 1;
     %jmp T_2;
     .thread T_2;
-    .scope S_0000022fd97b4b00;
+    .scope S_0000025acd5ec190;
 T_3 ;
-    %vpi_call 2 61 "$dumpfile", "testbenches/results/waveforms/MEM_WB_Register_tb_result.vcd" {0 0 0};
-    %vpi_call 2 62 "$dumpvars", 32'sb00000000000000000000000000000000, S_0000022fd97db390 {0 0 0};
-    %vpi_call 2 65 "$display", "==================== MEM_WB_Register Test START ====================\012" {0 0 0};
+    %vpi_call 2 65 "$dumpfile", "testbenches/results/waveforms/MEM_WB_Register_tb_result.vcd" {0 0 0};
+    %vpi_call 2 66 "$dumpvars", 32'sb00000000000000000000000000000000, S_0000025acd5ec320 {0 0 0};
+    %vpi_call 2 69 "$display", "==================== MEM_WB_Register Test START ====================\012" {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022fd983cf70_0, 0, 1;
+    %store/vec4 v0000025acd6879b0_0, 0, 1;
     %delay 30000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022fd983cf70_0, 0, 1;
-    %wait E_0000022fd98d97e0;
-    %vpi_call 2 72 "$display", "Input now" {0 0 0};
-    %vpi_call 2 73 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 74 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 75 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 76 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
+    %store/vec4 v0000025acd6879b0_0, 0, 1;
+    %wait E_0000025acd617a00;
+    %vpi_call 2 76 "$display", "Input now" {0 0 0};
+    %vpi_call 2 77 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 78 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 79 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 80 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
     %delay 10000, 0;
-    %wait E_0000022fd98d98a0;
+    %wait E_0000025acd617580;
     %pushi/vec4 4, 0, 32;
-    %store/vec4 v0000022fd983b4c0_0, 0, 32;
+    %store/vec4 v0000025acd684e20_0, 0, 32;
     %pushi/vec4 2, 0, 3;
-    %store/vec4 v0000022fd983ae80_0, 0, 3;
+    %store/vec4 v0000025acd684f60_0, 0, 3;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022fd983ade0_0, 0, 32;
+    %store/vec4 v0000025acd685460_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022fd983a5c0_0, 0, 32;
+    %store/vec4 v0000025acd685320_0, 0, 32;
     %pushi/vec4 11, 0, 32;
-    %store/vec4 v0000022fd983ad40_0, 0, 32;
+    %store/vec4 v0000025acd6853c0_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022fd983a980_0, 0, 1;
+    %store/vec4 v0000025acd685000_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022fd983a660_0, 0, 1;
+    %store/vec4 v0000025acd685820_0, 0, 1;
+    %pushi/vec4 6, 0, 5;
+    %store/vec4 v0000025acd685500_0, 0, 5;
     %pushi/vec4 10, 0, 32;
-    %store/vec4 v0000022fd983af20_0, 0, 32;
-    %wait E_0000022fd98d97e0;
+    %store/vec4 v0000025acd6856e0_0, 0, 32;
+    %wait E_0000025acd617a00;
     %delay 1000, 0;
-    %vpi_call 2 91 "$display", "Test 1: Previous value should be output now" {0 0 0};
-    %vpi_call 2 92 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 93 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 94 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 95 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
-    %wait E_0000022fd98d97e0;
+    %vpi_call 2 96 "$display", "Test 1: Previous value should be output now" {0 0 0};
+    %vpi_call 2 97 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 98 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 99 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 100 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %wait E_0000025acd617a00;
     %delay 1000, 0;
-    %vpi_call 2 99 "$display", "Test 2: No input(should be same)" {0 0 0};
-    %vpi_call 2 100 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 101 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 102 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 103 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
-    %wait E_0000022fd98d98a0;
+    %vpi_call 2 104 "$display", "Test 2: No input(should be same)" {0 0 0};
+    %vpi_call 2 105 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 106 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 107 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 108 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %wait E_0000025acd617580;
     %pushi/vec4 8, 0, 32;
-    %store/vec4 v0000022fd983b4c0_0, 0, 32;
+    %store/vec4 v0000025acd684e20_0, 0, 32;
     %pushi/vec4 1, 0, 3;
-    %store/vec4 v0000022fd983ae80_0, 0, 3;
+    %store/vec4 v0000025acd684f60_0, 0, 3;
     %pushi/vec4 32, 0, 32;
-    %store/vec4 v0000022fd983ade0_0, 0, 32;
+    %store/vec4 v0000025acd685460_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022fd983a5c0_0, 0, 32;
+    %store/vec4 v0000025acd685320_0, 0, 32;
     %pushi/vec4 268435488, 0, 32;
-    %store/vec4 v0000022fd983ad40_0, 0, 32;
+    %store/vec4 v0000025acd6853c0_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022fd983a980_0, 0, 1;
+    %store/vec4 v0000025acd685000_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022fd983a660_0, 0, 1;
+    %store/vec4 v0000025acd685820_0, 0, 1;
+    %pushi/vec4 7, 0, 5;
+    %store/vec4 v0000025acd685500_0, 0, 5;
     %pushi/vec4 3735928559, 0, 32;
-    %store/vec4 v0000022fd983af20_0, 0, 32;
-    %vpi_call 2 115 "$display", "Test 3-1: new input now(should be same)" {0 0 0};
-    %vpi_call 2 116 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 117 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 118 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 119 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
-    %wait E_0000022fd98d97e0;
+    %store/vec4 v0000025acd6856e0_0, 0, 32;
+    %vpi_call 2 121 "$display", "Test 3-1: new input now(should be same)" {0 0 0};
+    %vpi_call 2 122 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 123 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 124 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 125 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %wait E_0000025acd617a00;
     %delay 1000, 0;
-    %vpi_call 2 122 "$display", "Test 3-2: Test 3-1 input should be output now \012" {0 0 0};
-    %vpi_call 2 123 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 124 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 125 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 126 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
+    %vpi_call 2 128 "$display", "Test 3-2: Test 3-1 input should be output now \012" {0 0 0};
+    %vpi_call 2 129 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 130 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 131 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 132 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022fd983cbb0_0, 0, 1;
+    %store/vec4 v0000025acd6868d0_0, 0, 1;
     %delay 10000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000022fd983cbb0_0, 0, 1;
-    %vpi_call 2 132 "$display", "Test 4: Flushed (should be NOP and zero)" {0 0 0};
-    %vpi_call 2 133 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 134 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 135 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 136 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
+    %store/vec4 v0000025acd6868d0_0, 0, 1;
+    %vpi_call 2 138 "$display", "Test 4: Flushed (should be NOP and zero)" {0 0 0};
+    %vpi_call 2 139 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 140 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 141 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 142 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
     %pushi/vec4 12, 0, 32;
-    %store/vec4 v0000022fd983b4c0_0, 0, 32;
+    %store/vec4 v0000025acd684e20_0, 0, 32;
     %pushi/vec4 3, 0, 3;
-    %store/vec4 v0000022fd983ae80_0, 0, 3;
+    %store/vec4 v0000025acd684f60_0, 0, 3;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022fd983ade0_0, 0, 32;
+    %store/vec4 v0000025acd685460_0, 0, 32;
     %pushi/vec4 3405691582, 0, 32;
-    %store/vec4 v0000022fd983a5c0_0, 0, 32;
+    %store/vec4 v0000025acd685320_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000022fd983ad40_0, 0, 32;
+    %store/vec4 v0000025acd6853c0_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022fd983a980_0, 0, 1;
+    %store/vec4 v0000025acd685000_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000022fd983a660_0, 0, 1;
+    %store/vec4 v0000025acd685820_0, 0, 1;
+    %pushi/vec4 17, 0, 5;
+    %store/vec4 v0000025acd685500_0, 0, 5;
     %pushi/vec4 3405691582, 0, 32;
-    %store/vec4 v0000022fd983af20_0, 0, 32;
-    %vpi_call 2 146 "$display", "Test 5-1: Input begin (should be same)" {0 0 0};
-    %vpi_call 2 147 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 148 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 149 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 150 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
+    %store/vec4 v0000025acd6856e0_0, 0, 32;
+    %vpi_call 2 153 "$display", "Test 5-1: Input begin (should be same)" {0 0 0};
+    %vpi_call 2 154 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 155 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 156 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 157 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
     %delay 10000, 0;
-    %vpi_call 2 152 "$display", "Test 5-2: Test 5-1's input should be output now" {0 0 0};
-    %vpi_call 2 153 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 154 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000022fd983b240_0, v0000022fd983b380_0, v0000022fd983a8e0_0, v0000022fd983aa20_0 {0 0 0};
-    %vpi_call 2 155 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |" {0 0 0};
-    %vpi_call 2 156 "$display", "|   %h   |  %h  |   %h    |    %h    |\012", v0000022fd983b2e0_0, v0000022fd983a7a0_0, v0000022fd983b060_0, v0000022fd983a700_0 {0 0 0};
-    %vpi_call 2 158 "$display", "\012====================  MEM_WB_Register Test END  ====================" {0 0 0};
-    %vpi_call 2 160 "$stop" {0 0 0};
+    %vpi_call 2 159 "$display", "Test 5-2: Test 5-1's input should be output now" {0 0 0};
+    %vpi_call 2 160 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
+    %vpi_call 2 161 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 162 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
+    %vpi_call 2 163 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %vpi_call 2 165 "$display", "\012====================  MEM_WB_Register Test END  ====================" {0 0 0};
+    %vpi_call 2 167 "$stop" {0 0 0};
     %end;
     .thread T_3;
 # The file index is used to find the file name in the following table.

--- a/RV32I/testbenches/results/waveforms/EX_MEM_Register_tb_result.vcd
+++ b/RV32I/testbenches/results/waveforms/EX_MEM_Register_tb_result.vcd
@@ -1,5 +1,5 @@
 $date
-	Fri May 23 20:45:23 2025
+	Fri May 23 23:45:19 2025
 $end
 $version
 	Icarus Verilog
@@ -18,50 +18,54 @@ $var wire 1 & EX_memory_read $end
 $var wire 1 ' EX_memory_write $end
 $var wire 7 ( EX_opcode [6:0] $end
 $var wire 32 ) EX_pc_plus_4 [31:0] $end
-$var wire 32 * EX_read_data2 [31:0] $end
-$var wire 3 + EX_register_file_write_data_select [2:0] $end
-$var wire 1 , EX_register_write_enable $end
-$var wire 1 - clk $end
-$var wire 1 . flush $end
-$var wire 1 / reset $end
-$var parameter 32 0 XLEN $end
-$var reg 32 1 MEM_alu_result [31:0] $end
-$var reg 32 2 MEM_csr_read_data [31:0] $end
-$var reg 1 3 MEM_csr_write_enable $end
-$var reg 3 4 MEM_funct3 [2:0] $end
-$var reg 32 5 MEM_imm [31:0] $end
-$var reg 1 6 MEM_memory_read $end
-$var reg 1 7 MEM_memory_write $end
-$var reg 7 8 MEM_opcode [6:0] $end
-$var reg 32 9 MEM_pc_plus_4 [31:0] $end
-$var reg 32 : MEM_read_data2 [31:0] $end
-$var reg 3 ; MEM_register_file_write_data_select [2:0] $end
-$var reg 1 < MEM_register_write_enable $end
+$var wire 5 * EX_rd [4:0] $end
+$var wire 32 + EX_read_data2 [31:0] $end
+$var wire 3 , EX_register_file_write_data_select [2:0] $end
+$var wire 1 - EX_register_write_enable $end
+$var wire 1 . clk $end
+$var wire 1 / flush $end
+$var wire 1 0 reset $end
+$var parameter 32 1 XLEN $end
+$var reg 32 2 MEM_alu_result [31:0] $end
+$var reg 32 3 MEM_csr_read_data [31:0] $end
+$var reg 1 4 MEM_csr_write_enable $end
+$var reg 3 5 MEM_funct3 [2:0] $end
+$var reg 32 6 MEM_imm [31:0] $end
+$var reg 1 7 MEM_memory_read $end
+$var reg 1 8 MEM_memory_write $end
+$var reg 7 9 MEM_opcode [6:0] $end
+$var reg 32 : MEM_pc_plus_4 [31:0] $end
+$var reg 5 ; MEM_rd [4:0] $end
+$var reg 32 < MEM_read_data2 [31:0] $end
+$var reg 3 = MEM_register_file_write_data_select [2:0] $end
+$var reg 1 > MEM_register_write_enable $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
 $comment Show the parameter values. $end
 $dumpall
-b100000 0
+b100000 1
 $end
 #0
 $dumpvars
-0<
+0>
+b0 =
+b0 <
 b0 ;
 b0 :
 b0 9
-b0 8
+08
 07
-06
+b0 6
 b0 5
-b0 4
-03
+04
+b0 3
 b0 2
-b0 1
-1/
+10
+0/
 0.
-0-
-x,
+x-
+bx ,
 bx +
 bx *
 bx )
@@ -75,122 +79,130 @@ bx "
 bx !
 $end
 #5000
-1-
+1.
 #10000
-0-
+0.
 #15000
-1-
+1.
 #20000
-0-
+0.
 #25000
-1-
+1.
 #30000
-0-
-0/
+0.
+00
 #35000
-bx 2
-bx 5
-bx :
-bx 4
-bx 8
-x3
-x<
+bx 3
+bx 6
+bx <
 bx ;
-x7
-x6
+bx 5
 bx 9
-1-
+x4
+x>
+bx =
+x8
+x7
+bx :
+1.
 #40000
-0-
+0.
 #45000
-1-
+1.
 #50000
 b10000000000000000000001000000 !
 b0 "
 b10000 %
-b11011110101011011011111011101111 *
+b11011110101011011011111011101111 +
+b1100 *
 b10 $
 b100011 (
 0#
-1,
-b0 +
+1-
+b0 ,
 1'
 0&
 b1000 )
-0-
+0.
 #55000
-b0 2
-b10000 5
-b11011110101011011011111011101111 :
-b10 4
-b100011 8
-03
-1<
-b0 ;
-17
-06
-b1000 9
-1-
+b0 3
+b10000 6
+b11011110101011011011111011101111 <
+b1100 ;
+b10 5
+b100011 9
+04
+1>
+b0 =
+18
+07
+b1000 :
+1.
 #60000
-0-
+0.
 #65000
-1-
+1.
 #70000
 b100000000000000000000000110000 !
 b11000 %
-b0 *
+b0 +
+b1111 *
 b11 (
 1#
-0,
-b1 +
+0-
+b1 ,
 0'
 1&
 b10000 )
-0-
+0.
 #75000
-b11000 5
-b0 :
-b11 8
-13
-0<
-b1 ;
-07
-16
-b10000 9
-1-
-#76000
+b11000 6
+b0 <
+b1111 ;
+b11 9
+14
+0>
+b1 =
+08
+17
+b10000 :
 1.
+#76000
+1/
 #80000
-0-
+0.
 #85000
-b0 5
-b0 4
-b0 8
-03
+b0 6
 b0 ;
-06
+b0 5
 b0 9
-1-
+04
+b0 =
+07
+b0 :
+1.
 #86000
 b1011 !
 b10010001101000101011001111000 "
 b0 %
-b110 *
+b110 +
+b10011 *
 b0 $
 b110011 (
-1,
-b0 +
+1-
+b0 ,
 0&
 b11000 )
-0.
+0/
 #90000
-0-
+0.
 #95000
-b10010001101000101011001111000 2
-b110 :
-b110011 8
-13
-1<
-b11000 9
-1-
+b10010001101000101011001111000 3
+b110 <
+b10011 ;
+b110011 9
+14
+1>
+b11000 :
+1.
 #96000

--- a/RV32I/testbenches/results/waveforms/ID_EX_Register_tb_result.vcd
+++ b/RV32I/testbenches/results/waveforms/ID_EX_Register_tb_result.vcd
@@ -1,5 +1,5 @@
 $date
-	Fri May 23 20:36:29 2025
+	Fri May 23 23:42:02 2025
 $end
 $version
 	Icarus Verilog
@@ -25,71 +25,75 @@ $var wire 7 - ID_opcode [6:0] $end
 $var wire 32 . ID_pc [31:0] $end
 $var wire 32 / ID_pc_plus_4 [31:0] $end
 $var wire 12 0 ID_raw_imm [11:0] $end
-$var wire 32 1 ID_read_data1 [31:0] $end
-$var wire 32 2 ID_read_data2 [31:0] $end
-$var wire 3 3 ID_register_file_write_data_select [2:0] $end
-$var wire 1 4 ID_register_write_enable $end
-$var wire 5 5 ID_rs1 [4:0] $end
-$var wire 1 6 clk $end
-$var wire 1 7 flush $end
-$var wire 1 8 reset $end
-$var parameter 32 9 XLEN $end
-$var reg 2 : EX_alu_src_A_select [1:0] $end
-$var reg 3 ; EX_alu_src_B_select [2:0] $end
-$var reg 1 < EX_branch $end
-$var reg 1 = EX_branch_estimation $end
-$var reg 32 > EX_csr_read_data [31:0] $end
-$var reg 1 ? EX_csr_write_enable $end
-$var reg 3 @ EX_funct3 [2:0] $end
-$var reg 7 A EX_funct7 [6:0] $end
-$var reg 32 B EX_imm [31:0] $end
-$var reg 1 C EX_jump $end
-$var reg 1 D EX_memory_read $end
-$var reg 1 E EX_memory_write $end
-$var reg 7 F EX_opcode [6:0] $end
-$var reg 32 G EX_pc [31:0] $end
-$var reg 32 H EX_pc_plus_4 [31:0] $end
-$var reg 12 I EX_raw_imm [11:0] $end
-$var reg 32 J EX_read_data1 [31:0] $end
-$var reg 32 K EX_read_data2 [31:0] $end
-$var reg 3 L EX_register_file_write_data_select [2:0] $end
-$var reg 1 M EX_register_write_enable $end
-$var reg 5 N EX_rs1 [4:0] $end
+$var wire 5 1 ID_rd [4:0] $end
+$var wire 32 2 ID_read_data1 [31:0] $end
+$var wire 32 3 ID_read_data2 [31:0] $end
+$var wire 3 4 ID_register_file_write_data_select [2:0] $end
+$var wire 1 5 ID_register_write_enable $end
+$var wire 5 6 ID_rs1 [4:0] $end
+$var wire 1 7 clk $end
+$var wire 1 8 flush $end
+$var wire 1 9 reset $end
+$var parameter 32 : XLEN $end
+$var reg 2 ; EX_alu_src_A_select [1:0] $end
+$var reg 3 < EX_alu_src_B_select [2:0] $end
+$var reg 1 = EX_branch $end
+$var reg 1 > EX_branch_estimation $end
+$var reg 32 ? EX_csr_read_data [31:0] $end
+$var reg 1 @ EX_csr_write_enable $end
+$var reg 3 A EX_funct3 [2:0] $end
+$var reg 7 B EX_funct7 [6:0] $end
+$var reg 32 C EX_imm [31:0] $end
+$var reg 1 D EX_jump $end
+$var reg 1 E EX_memory_read $end
+$var reg 1 F EX_memory_write $end
+$var reg 7 G EX_opcode [6:0] $end
+$var reg 32 H EX_pc [31:0] $end
+$var reg 32 I EX_pc_plus_4 [31:0] $end
+$var reg 12 J EX_raw_imm [11:0] $end
+$var reg 5 K EX_rd [4:0] $end
+$var reg 32 L EX_read_data1 [31:0] $end
+$var reg 32 M EX_read_data2 [31:0] $end
+$var reg 3 N EX_register_file_write_data_select [2:0] $end
+$var reg 1 O EX_register_write_enable $end
+$var reg 5 P EX_rs1 [4:0] $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
 $comment Show the parameter values. $end
 $dumpall
-b100000 9
+b100000 :
 $end
 #0
 $dumpvars
+b0 P
+0O
 b0 N
-0M
+b0 M
 b0 L
 b0 K
 b0 J
 b0 I
 b0 H
 b0 G
-b0 F
+0F
 0E
 0D
-0C
+b0 C
 b0 B
 b0 A
-b0 @
-0?
-b0 >
+0@
+b0 ?
+0>
 0=
-0<
+b0 <
 b0 ;
-b0 :
-18
+19
+08
 07
-06
-bx 5
-x4
+bx 6
+x5
+bx 4
 bx 3
 bx 2
 bx 1
@@ -111,58 +115,60 @@ bx "
 bx !
 $end
 #5000
-16
+17
 #10000
-06
+07
 #15000
-16
+17
 #20000
-06
+07
 #25000
-16
+17
 #30000
-06
-08
+07
+09
 #35000
-bx >
-bx B
-bx N
-bx K
-bx J
-bx I
-bx A
-bx @
-bx F
-bx ;
-bx :
-x<
-x?
-xM
+bx ?
+bx C
+bx P
+bx M
 bx L
+bx J
+bx K
+bx B
+bx A
+bx G
+bx <
+bx ;
+x=
+x@
+xO
+bx N
+xF
 xE
 xD
-xC
-x=
+x>
+bx I
 bx H
-bx G
-16
+17
 #40000
-06
+07
 #45000
-16
+17
 #50000
 b0 %
 b0 )
-b1100 5
-b10111011101110111011101110111011 2
-b10101010101010101010101010101010 1
+b1100 6
+b10111011101110111011101110111011 3
+b10101010101010101010101010101010 2
 b0 0
+b110 1
 b11110 (
 b10 '
 b11000 -
 0&
-04
-b1 3
+05
+b1 4
 0,
 0+
 b10 "
@@ -172,106 +178,112 @@ b1 !
 0$
 b100 /
 b0 .
-06
+07
 #55000
-b0 >
-b0 B
-b1100 N
-b10111011101110111011101110111011 K
-b10101010101010101010101010101010 J
-b0 I
-b11110 A
-b10 @
-b11000 F
-b10 ;
-b1 :
-0<
-0?
-0M
-b1 L
-0E
-0D
-1C
+b0 ?
+b0 C
+b1100 P
+b10111011101110111011101110111011 M
+b10101010101010101010101010101010 L
+b0 J
+b110 K
+b11110 B
+b10 A
+b11000 G
+b10 <
+b1 ;
 0=
-b100 H
-b0 G
-16
+0@
+0O
+b1 N
+0F
+0E
+1D
+0>
+b100 I
+b0 H
+17
 #60000
-06
+07
 #65000
-16
+17
 #70000
-b101 5
-b1010 2
-b101 1
+b101 6
+b1010 3
+b101 2
+b1000 1
 b0 (
 b0 '
 b110011 -
-14
-b0 3
+15
+b0 4
 b0 "
 b0 !
 0*
-06
+07
 #75000
-b101 N
-b1010 K
-b101 J
+b101 P
+b1010 M
+b101 L
+b1000 K
+b0 B
 b0 A
-b0 @
-b110011 F
+b110011 G
+b0 <
 b0 ;
-b0 :
-1M
-b0 L
-0C
-16
-#76000
-17
-#80000
-06
-#85000
+1O
 b0 N
+0D
+17
+#76000
+18
+#80000
+07
+#85000
+b0 P
+b0 M
+b0 L
 b0 K
-b0 J
-b0 F
-0M
-b0 H
-16
+b0 G
+0O
+b0 I
+17
 #86000
 b11110000 )
-b10 5
-b0 2
-b100 1
+b10 6
+b0 3
+b100 2
 b11110000 0
+b1111 1
 b10 '
 b11 -
 1&
-04
-b1 3
+05
+b1 4
 1+
 b1 "
 1#
 1$
 b10000000000000001000000000100 /
 b10000000000000001000000000000 .
-07
+08
 #90000
-06
+07
 #95000
-b11110000 B
-b10 N
-b100 J
-b11110000 I
-b10 @
-b11 F
-b1 ;
-1<
-1?
-b1 L
-1D
+b11110000 C
+b10 P
+b100 L
+b11110000 J
+b1111 K
+b10 A
+b11 G
+b1 <
 1=
-b10000000000000001000000000100 H
-b10000000000000001000000000000 G
-16
+1@
+b1 N
+1E
+1>
+b10000000000000001000000000100 I
+b10000000000000001000000000000 H
+17
 #96000

--- a/RV32I/testbenches/results/waveforms/MEM_WB_Register_tb_result.vcd
+++ b/RV32I/testbenches/results/waveforms/MEM_WB_Register_tb_result.vcd
@@ -1,5 +1,5 @@
 $date
-	Fri May 23 20:05:13 2025
+	Fri May 23 23:48:57 2025
 $end
 $version
 	Icarus Verilog
@@ -14,42 +14,46 @@ $var wire 32 " MEM_csr_read_data [31:0] $end
 $var wire 1 # MEM_csr_write_enable $end
 $var wire 32 $ MEM_imm [31:0] $end
 $var wire 32 % MEM_pc_plus_4 [31:0] $end
-$var wire 32 & MEM_register_file_write_data [31:0] $end
-$var wire 3 ' MEM_register_file_write_data_select [2:0] $end
-$var wire 1 ( MEM_register_write_enable $end
-$var wire 1 ) clk $end
-$var wire 1 * flush $end
-$var wire 1 + reset $end
-$var parameter 32 , XLEN $end
-$var reg 32 - WB_alu_result [31:0] $end
-$var reg 32 . WB_csr_read_data [31:0] $end
-$var reg 1 / WB_csr_write_enable $end
-$var reg 32 0 WB_imm [31:0] $end
-$var reg 32 1 WB_pc_plus_4 [31:0] $end
-$var reg 32 2 WB_register_file_write_data [31:0] $end
-$var reg 3 3 WB_register_file_write_data_select [2:0] $end
-$var reg 1 4 WB_register_write_enable $end
+$var wire 5 & MEM_rd [4:0] $end
+$var wire 32 ' MEM_register_file_write_data [31:0] $end
+$var wire 3 ( MEM_register_file_write_data_select [2:0] $end
+$var wire 1 ) MEM_register_write_enable $end
+$var wire 1 * clk $end
+$var wire 1 + flush $end
+$var wire 1 , reset $end
+$var parameter 32 - XLEN $end
+$var reg 32 . WB_alu_result [31:0] $end
+$var reg 32 / WB_csr_read_data [31:0] $end
+$var reg 1 0 WB_csr_write_enable $end
+$var reg 32 1 WB_imm [31:0] $end
+$var reg 32 2 WB_pc_plus_4 [31:0] $end
+$var reg 5 3 WB_rd [4:0] $end
+$var reg 32 4 WB_register_file_write_data [31:0] $end
+$var reg 3 5 WB_register_file_write_data_select [2:0] $end
+$var reg 1 6 WB_register_write_enable $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
 $comment Show the parameter values. $end
 $dumpall
-b100000 ,
+b100000 -
 $end
 #0
 $dumpvars
-04
+06
+b0 5
+b0 4
 b0 3
 b0 2
 b0 1
-b0 0
-0/
+00
+b0 /
 b0 .
-b0 -
-1+
+1,
+0+
 0*
-0)
-x(
+x)
+bx (
 bx '
 bx &
 bx %
@@ -59,99 +63,107 @@ bx "
 bx !
 $end
 #5000
-1)
+1*
 #10000
-0)
+0*
 #15000
-1)
+1*
 #20000
-0)
+0*
 #25000
-1)
+1*
 #30000
-0)
-0+
+0*
+0,
 #35000
-bx 2
-x/
-x4
-bx -
-bx .
-bx 0
+bx 4
 bx 3
+x0
+x6
+bx .
+bx /
 bx 1
-1)
+bx 5
+bx 2
+1*
 #40000
-0)
+0*
 #45000
-1)
+1*
 #50000
-b1010 &
+b1010 '
+b110 &
 0#
-1(
+1)
 b1011 !
 b0 "
 b0 $
-b10 '
+b10 (
 b100 %
-0)
+0*
 #55000
-b1010 2
-0/
-14
-b1011 -
-b0 .
-b0 0
-b10 3
-b100 1
-1)
+b1010 4
+b110 3
+00
+16
+b1011 .
+b0 /
+b0 1
+b10 5
+b100 2
+1*
 #60000
-0)
+0*
 #65000
-1)
+1*
 #70000
-b11011110101011011011111011101111 &
+b11011110101011011011111011101111 '
+b111 &
 b10000000000000000000000100000 !
 b100000 $
-b1 '
+b1 (
 b1000 %
-0)
+0*
 #75000
-b11011110101011011011111011101111 2
-b10000000000000000000000100000 -
-b100000 0
-b1 3
-b1000 1
-1)
-#76000
+b11011110101011011011111011101111 4
+b111 3
+b10000000000000000000000100000 .
+b100000 1
+b1 5
+b1000 2
 1*
+#76000
+1+
 #80000
-0)
+0*
 #85000
-b0 2
-04
-b0 -
-b0 0
+b0 4
 b0 3
+06
+b0 .
 b0 1
-1)
+b0 5
+b0 2
+1*
 #86000
-b11001010111111101011101010111110 &
+b11001010111111101011101010111110 '
+b10001 &
 1#
 b0 !
 b11001010111111101011101010111110 "
 b0 $
-b11 '
+b11 (
 b1100 %
-0*
+0+
 #90000
-0)
+0*
 #95000
-b11001010111111101011101010111110 2
-1/
-14
-b11001010111111101011101010111110 .
-b11 3
-b1100 1
-1)
+b11001010111111101011101010111110 4
+b10001 3
+10
+16
+b11001010111111101011101010111110 /
+b11 5
+b1100 2
+1*
 #96000


### PR DESCRIPTION
Added the missing `rd` signal required for the **Register File**'s write operation in the WriteBack pipeline stage.
Previously, this signal had not been pipelined. 

Now, the following pipeline registers include the `rd` (register destination) signal.
- ID_EX_Register
- EX_MEM_Register
- MEM_WB_Register