### PR TITLE
[Feat] Implement Forward Unit and its testbench

### DIFF
--- a/RV32I/modules/Forward_Unit.v
+++ b/RV32I/modules/Forward_Unit.v
@@ -1,28 +1,38 @@
-module ForwardUnit (
-    input wire hazard_op                    // signal indicating data hazard has been occured
-    input wire [31:0] MEM_imm;              // from EX/MEM Register for LUI
-    input wire [31:0] MEM_alu_result;       
-    input wire [31:0] MEM_csr_read_data;
-    input wire [31:0] MEM_read_data;        // from Data Memory
-    input wire [31:0] MEM_pc_plus_4;        // from EX/MEM Register
-    input wire [6:0] MEM_opcode;            // from EX/MEM Register
-    
-    output reg [31:0] alu_forward_source_data_a;    // Forwarded source A data signal
-    output reg [31:0] alu_forward_source_data_b;    // Forwarded source B data signal
-    output reg [1:0] alu_forward_source_select_a; // ALU source A selection between normal source and forwarded source
-    output reg [1:0] alu_forward_source_select_b; // ALU source B selection between normal source and forwarded source
+`include "modules/headers/opcode.vh"
 
-    localparam OPCODE_LOAD = ;
+module ForwardUnit #(
+    parameter XLEN = 32
+)(
+    input wire [1:0] hazard_op,                    // signal indicating data hazard has been occured
+    input wire [XLEN-1:0] MEM_imm,              // from EX/MEM Register for LUI
+    input wire [XLEN-1:0] MEM_alu_result,       
+    input wire [XLEN-1:0] MEM_csr_read_data,
+    input wire [XLEN-1:0] MEM_read_data,        // from Data Memory
+    input wire [XLEN-1:0] MEM_pc_plus_4,        // from EX/MEM Register
+    input wire [6:0] MEM_opcode,            // from EX/MEM Register
+    
+    output wire [XLEN-1:0] alu_forward_source_data_a,    // Forwarded source A data signal
+    output wire [XLEN-1:0] alu_forward_source_data_b,    // Forwarded source B data signal
+    output wire [1:0] alu_forward_source_select_a, // ALU source A selection between normal source and forwarded source
+    output wire [1:0] alu_forward_source_select_b // ALU source B selection between normal source and forwarded source
+);
+    reg [31:0] forward_data_value;
+
+    assign alu_forward_source_select_a = hazard_op[0] ? 2'b10 : 2'b01;
+    assign alu_forward_source_select_b = hazard_op[1] ? 2'b10 : 2'b01;
+
+    assign alu_forward_source_data_a = hazard_op[0] ? forward_data_value : {XLEN{1'b0}};
+    assign alu_forward_source_data_b = hazard_op[1] ? forward_data_value : {XLEN{1'b0}};
 
     always @(*) begin
-        if (hazard_op == 1'b1) begin
-            case (param)
-                : 
-                default: 
-            endcase
-        end
-        
+        case (MEM_opcode)
+            `OPCODE_LOAD : forward_data_value = MEM_read_data;
+            `OPCODE_ENVIRONMENT : forward_data_value = MEM_csr_read_data;
+            `OPCODE_LUI : forward_data_value = MEM_imm;
+            `OPCODE_JAL :  forward_data_value = MEM_pc_plus_4;
+            `OPCODE_JALR : forward_data_value = MEM_pc_plus_4;
+            default: forward_data_value = MEM_alu_result;
+        endcase
     end
-);
     
 endmodule

--- a/RV32I/modules/Forward_Unit.v
+++ b/RV32I/modules/Forward_Unit.v
@@ -1,0 +1,28 @@
+module ForwardUnit (
+    input wire hazard_op                    // signal indicating data hazard has been occured
+    input wire [31:0] MEM_imm;              // from EX/MEM Register for LUI
+    input wire [31:0] MEM_alu_result;       
+    input wire [31:0] MEM_csr_read_data;
+    input wire [31:0] MEM_read_data;        // from Data Memory
+    input wire [31:0] MEM_pc_plus_4;        // from EX/MEM Register
+    input wire [6:0] MEM_opcode;            // from EX/MEM Register
+    
+    output reg [31:0] alu_forward_source_data_a;    // Forwarded source A data signal
+    output reg [31:0] alu_forward_source_data_b;    // Forwarded source B data signal
+    output reg [1:0] alu_forward_source_select_a; // ALU source A selection between normal source and forwarded source
+    output reg [1:0] alu_forward_source_select_b; // ALU source B selection between normal source and forwarded source
+
+    localparam OPCODE_LOAD = ;
+
+    always @(*) begin
+        if (hazard_op == 1'b1) begin
+            case (param)
+                : 
+                default: 
+            endcase
+        end
+        
+    end
+);
+    
+endmodule

--- a/RV32I/testbenches/Forward_Unit_tb.v
+++ b/RV32I/testbenches/Forward_Unit_tb.v
@@ -1,0 +1,84 @@
+`timescale 1ns/1ps
+`include "modules/headers/opcode.vh"
+
+module ForwardUnit_tb;
+localparam XLEN = 32;
+
+reg [1:0]  hazard_op;
+reg [XLEN-1:0] MEM_imm;
+reg [XLEN-1:0] MEM_alu_result;
+reg [XLEN-1:0] MEM_csr_read_data;
+reg [XLEN-1:0] MEM_read_data;
+reg [XLEN-1:0] MEM_pc_plus_4;
+reg [6:0] MEM_opcode;
+
+wire [XLEN-1:0] alu_forward_source_data_a;
+wire [XLEN-1:0] alu_forward_source_data_b;
+wire [1:0] alu_forward_source_select_a;
+wire [1:0] alu_forward_source_select_b;
+
+ForwardUnit forward_unit (
+    .hazard_op                 (hazard_op),
+    .MEM_imm                   (MEM_imm),
+    .MEM_alu_result            (MEM_alu_result),
+    .MEM_csr_read_data         (MEM_csr_read_data),
+    .MEM_read_data             (MEM_read_data),
+    .MEM_pc_plus_4             (MEM_pc_plus_4),
+    .MEM_opcode                (MEM_opcode),
+    .alu_forward_source_data_a (alu_forward_source_data_a),
+    .alu_forward_source_data_b (alu_forward_source_data_b),
+    .alu_forward_source_select_a(alu_forward_source_select_a),
+    .alu_forward_source_select_b(alu_forward_source_select_b)
+);
+
+initial begin
+    $dumpfile("testbenches/results/waveforms/ForwardUnit_tb.vcd");
+    $dumpvars(0, ForwardUnit_tb);
+
+    $display("==================== Forward Unit Test START ====================");
+    // Initialize signals
+    hazard_op = 2'b00;
+    MEM_imm   = 32'hAAAA_0000;
+    MEM_alu_result    = 32'hDEAD_BEEF;
+    MEM_csr_read_data = 32'hFACE_CAFE;
+    MEM_read_data     = 32'h1111_2222;
+    MEM_pc_plus_4     = 32'h0040_1004;
+
+    // Test 0 : no hazard (sel = 01, data = 0)
+    MEM_opcode = `OPCODE_RTYPE; // ALU
+    #1;
+    $display("Test 0 : no hazard (sel = 01, data = 0)");
+    $display("selA = %b selB = %b fwdA = %h fwdB = %h\n", alu_forward_source_select_a, alu_forward_source_select_b, alu_forward_source_data_a, alu_forward_source_data_b);
+
+    // Test 1 : rs1 hazard only (LOAD)
+    hazard_op = 2'b01;
+    MEM_opcode = `OPCODE_LOAD;
+    #1;
+    $display("Test 1 : rs1 hazard only (LOAD)");
+    $display("selA = %b selB = %b fwdA = %h fwdB = %h\n", alu_forward_source_select_a, alu_forward_source_select_b, alu_forward_source_data_a, alu_forward_source_data_b);
+    
+    // Test 2 : rs2 hazard only (JALR)
+    hazard_op = 2'b10;
+    MEM_opcode = `OPCODE_JALR;
+    #1;
+    $display("Test 2 : rs2 hazard only (JALR)");
+    $display("selA = %b selB = %b fwdA = %h fwdB = %h\n", alu_forward_source_select_a, alu_forward_source_select_b, alu_forward_source_data_a, alu_forward_source_data_b);
+
+    // Test 0 (again) : no hazard (sel=01, data=0)
+    MEM_opcode = `OPCODE_RTYPE; // ALU
+    hazard_op = 2'b00;
+    #1;
+    $display("Test 0 : no hazard (sel = 01, data = 0)");
+    $display("selA = %b selB = %b fwdA = %h fwdB = %h\n", alu_forward_source_select_a, alu_forward_source_select_b, alu_forward_source_data_a, alu_forward_source_data_b);
+
+    // Test 3 : both hazards (CSR) ------------
+    hazard_op = 2'b11;
+    MEM_opcode = `OPCODE_ENVIRONMENT;
+    #1;
+    $display("Test 3 : both hazards (CSR)");
+    $display("selA = %b selB = %b fwdA = %h fwdB = %h\n", alu_forward_source_select_a, alu_forward_source_select_b, alu_forward_source_data_a, alu_forward_source_data_b);
+
+    $display("\n====================  Forward Unit Test END  ====================");
+    $finish;
+end
+endmodule

--- a/RV32I/testbenches/results/Forward_Unit_result.vvp
+++ b/RV32I/testbenches/results/Forward_Unit_result.vvp
@@ -1,0 +1,187 @@
+#! /c/Source/iverilog-install/bin/vvp
+:ivl_version "12.0 (devel)" "(s20150603-1539-g2693dd32b)";
+:ivl_delay_selection "TYPICAL";
+:vpi_time_precision - 12;
+:vpi_module "C:\iverilog\lib\ivl\system.vpi";
+:vpi_module "C:\iverilog\lib\ivl\vhdl_sys.vpi";
+:vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
+:vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
+:vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
+S_0000022058bbcd30 .scope module, "ForwardUnit_tb" "ForwardUnit_tb" 2 4;
+ .timescale -9 -12;
+P_0000022058bba490 .param/l "XLEN" 1 2 5, +C4<00000000000000000000000000100000>;
+v0000022058c282e0_0 .var "MEM_alu_result", 31 0;
+v0000022058c287e0_0 .var "MEM_csr_read_data", 31 0;
+v0000022058c281a0_0 .var "MEM_imm", 31 0;
+v0000022058c28380_0 .var "MEM_opcode", 6 0;
+v0000022058c28560_0 .var "MEM_pc_plus_4", 31 0;
+v0000022058c2ab20_0 .var "MEM_read_data", 31 0;
+v0000022058c2aa80_0 .net "alu_forward_source_data_a", 31 0, L_0000022058c2abc0;  1 drivers
+v0000022058c2ad00_0 .net "alu_forward_source_data_b", 31 0, L_0000022058c2a6c0;  1 drivers
+v0000022058c2b520_0 .net "alu_forward_source_select_a", 1 0, L_0000022058c2a620;  1 drivers
+v0000022058c2a800_0 .net "alu_forward_source_select_b", 1 0, L_0000022058c2a580;  1 drivers
+v0000022058c2b340_0 .var "hazard_op", 1 0;
+S_0000022058bc9510 .scope module, "forward_unit" "ForwardUnit" 2 20, 3 3 0, S_0000022058bbcd30;
+ .timescale 0 0;
+    .port_info 0 /INPUT 2 "hazard_op";
+    .port_info 1 /INPUT 32 "MEM_imm";
+    .port_info 2 /INPUT 32 "MEM_alu_result";
+    .port_info 3 /INPUT 32 "MEM_csr_read_data";
+    .port_info 4 /INPUT 32 "MEM_read_data";
+    .port_info 5 /INPUT 32 "MEM_pc_plus_4";
+    .port_info 6 /INPUT 7 "MEM_opcode";
+    .port_info 7 /OUTPUT 32 "alu_forward_source_data_a";
+    .port_info 8 /OUTPUT 32 "alu_forward_source_data_b";
+    .port_info 9 /OUTPUT 2 "alu_forward_source_select_a";
+    .port_info 10 /OUTPUT 2 "alu_forward_source_select_b";
+P_0000022058bba310 .param/l "XLEN" 0 3 4, +C4<00000000000000000000000000100000>;
+v0000022058bbcec0_0 .net "MEM_alu_result", 31 0, v0000022058c282e0_0;  1 drivers
+v0000022058bc9760_0 .net "MEM_csr_read_data", 31 0, v0000022058c287e0_0;  1 drivers
+v0000022058c28ec0_0 .net "MEM_imm", 31 0, v0000022058c281a0_0;  1 drivers
+v0000022058c28ce0_0 .net "MEM_opcode", 6 0, v0000022058c28380_0;  1 drivers
+v0000022058c28420_0 .net "MEM_pc_plus_4", 31 0, v0000022058c28560_0;  1 drivers
+v0000022058c28a60_0 .net "MEM_read_data", 31 0, v0000022058c2ab20_0;  1 drivers
+v0000022058c286a0_0 .net *"_ivl_1", 0 0, L_0000022058c2ada0;  1 drivers
+L_0000022058c2c8e8 .functor BUFT 1, C4<10>, C4<0>, C4<0>, C4<0>;
+v0000022058c28880_0 .net/2u *"_ivl_10", 1 0, L_0000022058c2c8e8;  1 drivers
+L_0000022058c2c930 .functor BUFT 1, C4<01>, C4<0>, C4<0>, C4<0>;
+v0000022058c28060_0 .net/2u *"_ivl_12", 1 0, L_0000022058c2c930;  1 drivers
+v0000022058c28d80_0 .net *"_ivl_17", 0 0, L_0000022058c2ba20;  1 drivers
+L_0000022058c2c978 .functor BUFT 1, C4<00000000000000000000000000000000>, C4<0>, C4<0>, C4<0>;
+v0000022058c28240_0 .net/2u *"_ivl_18", 31 0, L_0000022058c2c978;  1 drivers
+L_0000022058c2c858 .functor BUFT 1, C4<10>, C4<0>, C4<0>, C4<0>;
+v0000022058c284c0_0 .net/2u *"_ivl_2", 1 0, L_0000022058c2c858;  1 drivers
+v0000022058c289c0_0 .net *"_ivl_23", 0 0, L_0000022058c2b700;  1 drivers
+L_0000022058c2c9c0 .functor BUFT 1, C4<00000000000000000000000000000000>, C4<0>, C4<0>, C4<0>;
+v0000022058c28740_0 .net/2u *"_ivl_24", 31 0, L_0000022058c2c9c0;  1 drivers
+L_0000022058c2c8a0 .functor BUFT 1, C4<01>, C4<0>, C4<0>, C4<0>;
+v0000022058c28920_0 .net/2u *"_ivl_4", 1 0, L_0000022058c2c8a0;  1 drivers
+v0000022058c28b00_0 .net *"_ivl_9", 0 0, L_0000022058c2be80;  1 drivers
+v0000022058c28600_0 .net "alu_forward_source_data_a", 31 0, L_0000022058c2abc0;  alias, 1 drivers
+v0000022058c28ba0_0 .net "alu_forward_source_data_b", 31 0, L_0000022058c2a6c0;  alias, 1 drivers
+v0000022058c28e20_0 .net "alu_forward_source_select_a", 1 0, L_0000022058c2a620;  alias, 1 drivers
+v0000022058c28c40_0 .net "alu_forward_source_select_b", 1 0, L_0000022058c2a580;  alias, 1 drivers
+v0000022058c28f60_0 .var "forward_data_value", 31 0;
+v0000022058c28100_0 .net "hazard_op", 1 0, v0000022058c2b340_0;  1 drivers
+E_0000022058bb9f10/0 .event anyedge, v0000022058c28ce0_0, v0000022058c28a60_0, v0000022058bc9760_0, v0000022058c28ec0_0;
+E_0000022058bb9f10/1 .event anyedge, v0000022058c28420_0, v0000022058bbcec0_0;
+E_0000022058bb9f10 .event/or E_0000022058bb9f10/0, E_0000022058bb9f10/1;
+L_0000022058c2ada0 .part v0000022058c2b340_0, 0, 1;
+L_0000022058c2a620 .functor MUXZ 2, L_0000022058c2c8a0, L_0000022058c2c858, L_0000022058c2ada0, C4<>;
+L_0000022058c2be80 .part v0000022058c2b340_0, 1, 1;
+L_0000022058c2a580 .functor MUXZ 2, L_0000022058c2c930, L_0000022058c2c8e8, L_0000022058c2be80, C4<>;
+L_0000022058c2ba20 .part v0000022058c2b340_0, 0, 1;
+L_0000022058c2abc0 .functor MUXZ 32, L_0000022058c2c978, v0000022058c28f60_0, L_0000022058c2ba20, C4<>;
+L_0000022058c2b700 .part v0000022058c2b340_0, 1, 1;
+L_0000022058c2a6c0 .functor MUXZ 32, L_0000022058c2c9c0, v0000022058c28f60_0, L_0000022058c2b700, C4<>;
+    .scope S_0000022058bc9510;
+T_0 ;
+    %wait E_0000022058bb9f10;
+    %load/vec4 v0000022058c28ce0_0;
+    %dup/vec4;
+    %pushi/vec4 3, 0, 7;
+    %cmp/u;
+    %jmp/1 T_0.0, 6;
+    %dup/vec4;
+    %pushi/vec4 115, 0, 7;
+    %cmp/u;
+    %jmp/1 T_0.1, 6;
+    %dup/vec4;
+    %pushi/vec4 55, 0, 7;
+    %cmp/u;
+    %jmp/1 T_0.2, 6;
+    %dup/vec4;
+    %pushi/vec4 111, 0, 7;
+    %cmp/u;
+    %jmp/1 T_0.3, 6;
+    %dup/vec4;
+    %pushi/vec4 103, 0, 7;
+    %cmp/u;
+    %jmp/1 T_0.4, 6;
+    %load/vec4 v0000022058bbcec0_0;
+    %store/vec4 v0000022058c28f60_0, 0, 32;
+    %jmp T_0.6;
+T_0.0 ;
+    %load/vec4 v0000022058c28a60_0;
+    %store/vec4 v0000022058c28f60_0, 0, 32;
+    %jmp T_0.6;
+T_0.1 ;
+    %load/vec4 v0000022058bc9760_0;
+    %store/vec4 v0000022058c28f60_0, 0, 32;
+    %jmp T_0.6;
+T_0.2 ;
+    %load/vec4 v0000022058c28ec0_0;
+    %store/vec4 v0000022058c28f60_0, 0, 32;
+    %jmp T_0.6;
+T_0.3 ;
+    %load/vec4 v0000022058c28420_0;
+    %store/vec4 v0000022058c28f60_0, 0, 32;
+    %jmp T_0.6;
+T_0.4 ;
+    %load/vec4 v0000022058c28420_0;
+    %store/vec4 v0000022058c28f60_0, 0, 32;
+    %jmp T_0.6;
+T_0.6 ;
+    %pop/vec4 1;
+    %jmp T_0;
+    .thread T_0, $push;
+    .scope S_0000022058bbcd30;
+T_1 ;
+    %vpi_call 2 35 "$dumpfile", "testbenches/results/waveforms/ForwardUnit_tb.vcd" {0 0 0};
+    %vpi_call 2 36 "$dumpvars", 32'sb00000000000000000000000000000000, S_0000022058bbcd30 {0 0 0};
+    %vpi_call 2 38 "$display", "==================== Forward Unit Test START ====================" {0 0 0};
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0000022058c2b340_0, 0, 2;
+    %pushi/vec4 2863267840, 0, 32;
+    %store/vec4 v0000022058c281a0_0, 0, 32;
+    %pushi/vec4 3735928559, 0, 32;
+    %store/vec4 v0000022058c282e0_0, 0, 32;
+    %pushi/vec4 4207856382, 0, 32;
+    %store/vec4 v0000022058c287e0_0, 0, 32;
+    %pushi/vec4 286335522, 0, 32;
+    %store/vec4 v0000022058c2ab20_0, 0, 32;
+    %pushi/vec4 4198404, 0, 32;
+    %store/vec4 v0000022058c28560_0, 0, 32;
+    %pushi/vec4 51, 0, 7;
+    %store/vec4 v0000022058c28380_0, 0, 7;
+    %delay 1000, 0;
+    %vpi_call 2 50 "$display", "Test 0 : no hazard (sel = 01, data = 0)" {0 0 0};
+    %vpi_call 2 51 "$display", "selA = %b selB = %b fwdA = %h fwdB = %h\012", v0000022058c2b520_0, v0000022058c2a800_0, v0000022058c2aa80_0, v0000022058c2ad00_0 {0 0 0};
+    %pushi/vec4 1, 0, 2;
+    %store/vec4 v0000022058c2b340_0, 0, 2;
+    %pushi/vec4 3, 0, 7;
+    %store/vec4 v0000022058c28380_0, 0, 7;
+    %delay 1000, 0;
+    %vpi_call 2 57 "$display", "Test 1 : rs1 hazard only (LOAD)" {0 0 0};
+    %vpi_call 2 58 "$display", "selA = %b selB = %b fwdA = %h fwdB = %h\012", v0000022058c2b520_0, v0000022058c2a800_0, v0000022058c2aa80_0, v0000022058c2ad00_0 {0 0 0};
+    %pushi/vec4 2, 0, 2;
+    %store/vec4 v0000022058c2b340_0, 0, 2;
+    %pushi/vec4 103, 0, 7;
+    %store/vec4 v0000022058c28380_0, 0, 7;
+    %delay 1000, 0;
+    %vpi_call 2 64 "$display", "Test 2 : rs2 hazard only (JALR)" {0 0 0};
+    %vpi_call 2 65 "$display", "selA = %b selB = %b fwdA = %h fwdB = %h\012", v0000022058c2b520_0, v0000022058c2a800_0, v0000022058c2aa80_0, v0000022058c2ad00_0 {0 0 0};
+    %pushi/vec4 51, 0, 7;
+    %store/vec4 v0000022058c28380_0, 0, 7;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0000022058c2b340_0, 0, 2;
+    %delay 1000, 0;
+    %vpi_call 2 71 "$display", "Test 0 : no hazard (sel = 01, data = 0)" {0 0 0};
+    %vpi_call 2 72 "$display", "selA = %b selB = %b fwdA = %h fwdB = %h\012", v0000022058c2b520_0, v0000022058c2a800_0, v0000022058c2aa80_0, v0000022058c2ad00_0 {0 0 0};
+    %pushi/vec4 3, 0, 2;
+    %store/vec4 v0000022058c2b340_0, 0, 2;
+    %pushi/vec4 115, 0, 7;
+    %store/vec4 v0000022058c28380_0, 0, 7;
+    %delay 1000, 0;
+    %vpi_call 2 78 "$display", "Test 3 : both hazards (CSR)" {0 0 0};
+    %vpi_call 2 79 "$display", "selA = %b selB = %b fwdA = %h fwdB = %h\012", v0000022058c2b520_0, v0000022058c2a800_0, v0000022058c2aa80_0, v0000022058c2ad00_0 {0 0 0};
+    %vpi_call 2 81 "$display", "\012====================  Forward Unit Test END  ====================" {0 0 0};
+    %vpi_call 2 82 "$finish" {0 0 0};
+    %end;
+    .thread T_1;
+# The file index is used to find the file name in the following table.
+:file_names 4;
+    "N/A";
+    "<interactive>";
+    "testbenches/Forward_Unit_tb.v";
+    "modules/Forward_Unit.v";

--- a/RV32I/testbenches/results/waveforms/ForwardUnit_tb.vcd
+++ b/RV32I/testbenches/results/waveforms/ForwardUnit_tb.vcd
@@ -1,0 +1,119 @@
+$date
+	Sun May 25 13:17:08 2025
+$end
+$version
+	Icarus Verilog
+$end
+$timescale
+	1ps
+$end
+$scope module ForwardUnit_tb $end
+$var wire 2 ! alu_forward_source_select_b [1:0] $end
+$var wire 2 " alu_forward_source_select_a [1:0] $end
+$var wire 32 # alu_forward_source_data_b [31:0] $end
+$var wire 32 $ alu_forward_source_data_a [31:0] $end
+$var parameter 32 % XLEN $end
+$var reg 32 & MEM_alu_result [31:0] $end
+$var reg 32 ' MEM_csr_read_data [31:0] $end
+$var reg 32 ( MEM_imm [31:0] $end
+$var reg 7 ) MEM_opcode [6:0] $end
+$var reg 32 * MEM_pc_plus_4 [31:0] $end
+$var reg 32 + MEM_read_data [31:0] $end
+$var reg 2 , hazard_op [1:0] $end
+$scope module forward_unit $end
+$var wire 32 - MEM_alu_result [31:0] $end
+$var wire 32 . MEM_csr_read_data [31:0] $end
+$var wire 32 / MEM_imm [31:0] $end
+$var wire 7 0 MEM_opcode [6:0] $end
+$var wire 32 1 MEM_pc_plus_4 [31:0] $end
+$var wire 32 2 MEM_read_data [31:0] $end
+$var wire 2 3 hazard_op [1:0] $end
+$var wire 2 4 alu_forward_source_select_b [1:0] $end
+$var wire 2 5 alu_forward_source_select_a [1:0] $end
+$var wire 32 6 alu_forward_source_data_b [31:0] $end
+$var wire 32 7 alu_forward_source_data_a [31:0] $end
+$var parameter 32 8 XLEN $end
+$var reg 32 9 forward_data_value [31:0] $end
+$upscope $end
+$upscope $end
+$enddefinitions $end
+$comment Show the parameter values. $end
+$dumpall
+b100000 8
+b100000 %
+$end
+#0
+$dumpvars
+b11011110101011011011111011101111 9
+b0 7
+b0 6
+b1 5
+b1 4
+b0 3
+b10001000100010010001000100010 2
+b10000000001000000000100 1
+b110011 0
+b10101010101010100000000000000000 /
+b11111010110011101100101011111110 .
+b11011110101011011011111011101111 -
+b0 ,
+b10001000100010010001000100010 +
+b10000000001000000000100 *
+b110011 )
+b10101010101010100000000000000000 (
+b11111010110011101100101011111110 '
+b11011110101011011011111011101111 &
+b0 $
+b0 #
+b1 "
+b1 !
+$end
+#1000
+b10 "
+b10 5
+b10001000100010010001000100010 $
+b10001000100010010001000100010 7
+b10001000100010010001000100010 9
+b11 )
+b11 0
+b1 ,
+b1 3
+#2000
+b1 "
+b1 5
+b10 !
+b10 4
+b0 $
+b0 7
+b10000000001000000000100 #
+b10000000001000000000100 6
+b10000000001000000000100 9
+b1100111 )
+b1100111 0
+b10 ,
+b10 3
+#3000
+b1 !
+b1 4
+b0 #
+b0 6
+b11011110101011011011111011101111 9
+b0 ,
+b0 3
+b110011 )
+b110011 0
+#4000
+b10 "
+b10 5
+b10 !
+b10 4
+b11111010110011101100101011111110 $
+b11111010110011101100101011111110 7
+b11111010110011101100101011111110 #
+b11111010110011101100101011111110 6
+b11111010110011101100101011111110 9
+b1110011 )
+b1110011 0
+b11 ,
+b11 3
+#5000


### PR DESCRIPTION
## Implemented Forward Unit module and its testbench

The **Forward Unit** receives a 2-bit hazard identification signal, `hazard_op`, from the **Hazard Unit**. The signal encodings are as follows:

- 2'b01: `rs1` hazard
- 2'b10: `rs2` hazard
- 2'b11: both `rs1` and `rs2` hazards
- 2'b00: no hazard detected

When `hazard_op` is asserted indicating a data hazard, the _ALU source selection_ is updated from `2'b01` _(normal data flow)_ to `2'b10` to select the forwarded data as the _ALU input_. The MUX controlling this _ALU source selection_ will be implemented in the **RV32I46F_5SP** top module. The code reserves `2'b00` to represent a _non-selected_ state.

Based on the `hazard_op` signal and the opcode of the current instruction, the **Forward Unit** determines which value to forward:

- For ***load instructions***, it forwards `MEM_read_data` from the **Data Memory** module.
- For ***SYSTEM instructions*** (e.g., CSR operations), it forwards `MEM_csr_read_data` from the **CSR File**.
- For ***LUI instructions***, it forwards `MEM_imm`.
- For ***JAL and JALR instructions***, it forwards `MEM_pc_plus_4`.
- For all other instructions, it forwards `MEM_alu_result`.