### PR TITLE
[Feat] Revise MEM_WB_Register read_data signal name to BERF_WD and its testbench

### DIFF
--- a/RV32I/modules/MEM_WB_Register.v
+++ b/RV32I/modules/MEM_WB_Register.v
@@ -18,7 +18,7 @@ module MEM_WB_Register #(
     input wire [4:0] MEM_rd,
 
     // signals from MEM phase
-    input wire [XLEN-1:0] MEM_register_file_write_data,
+    input wire [XLEN-1:0] MEM_byte_enable_logic_register_file_write_data,
 
     // signals to MEM register
     output reg [XLEN-1:0] WB_pc_plus_4,
@@ -31,7 +31,7 @@ module MEM_WB_Register #(
     output reg WB_csr_write_enable,
     output reg [4:0] WB_rd,
 
-    output reg [XLEN-1:0] WB_register_file_write_data
+    output reg [XLEN-1:0] WB_byte_enable_logic_register_file_write_data
 );
 
 always @(posedge clk or posedge reset) begin
@@ -46,7 +46,7 @@ always @(posedge clk or posedge reset) begin
         WB_csr_write_enable <= 1'b0;
         WB_rd <= 5'b0;
         
-        WB_register_file_write_data <= {XLEN{1'b0}};
+        WB_byte_enable_logic_register_file_write_data <= {XLEN{1'b0}};
     end else begin
         WB_pc_plus_4 <= MEM_pc_plus_4;
 
@@ -58,7 +58,7 @@ always @(posedge clk or posedge reset) begin
         WB_csr_write_enable <= MEM_csr_write_enable;
         WB_rd <= MEM_rd;
         
-        WB_register_file_write_data <= MEM_register_file_write_data;
+        WB_byte_enable_logic_register_file_write_data <= MEM_byte_enable_logic_register_file_write_data;
     end
 end
 

--- a/RV32I/testbenches/MEM_WB_Register_tb.v
+++ b/RV32I/testbenches/MEM_WB_Register_tb.v
@@ -19,7 +19,7 @@ module MEM_WB_Register_tb;
     reg [4:0] MEM_rd;
 
     // signals from MEM phase
-    reg [XLEN-1:0] MEM_register_file_write_data;
+    reg [XLEN-1:0] MEM_byte_enable_logic_register_file_write_data;
 
     wire [XLEN-1:0] WB_pc_plus_4;
 
@@ -31,7 +31,7 @@ module MEM_WB_Register_tb;
     wire WB_csr_write_enable;
     wire [4:0] WB_rd;
 
-    wire [XLEN-1:0] WB_register_file_write_data;
+    wire [XLEN-1:0] WB_byte_enable_logic_register_file_write_data;
 
     MEM_WB_Register #(.XLEN(32)) mem_wb_register (
         .clk(clk),
@@ -46,7 +46,7 @@ module MEM_WB_Register_tb;
         .MEM_register_write_enable(MEM_register_write_enable),
         .MEM_csr_write_enable(MEM_csr_write_enable),
         .MEM_rd(MEM_rd),
-        .MEM_register_file_write_data(MEM_register_file_write_data),
+        .MEM_byte_enable_logic_register_file_write_data(MEM_byte_enable_logic_register_file_write_data),
 
         .WB_pc_plus_4(WB_pc_plus_4),
         .WB_register_file_write_data_select(WB_register_file_write_data_select),
@@ -56,7 +56,7 @@ module MEM_WB_Register_tb;
         .WB_register_write_enable(WB_register_write_enable),
         .WB_csr_write_enable(WB_csr_write_enable),
         .WB_rd(WB_rd),
-        .WB_register_file_write_data(WB_register_file_write_data)
+        .WB_byte_enable_logic_register_file_write_data(WB_byte_enable_logic_register_file_write_data)
     );
 
     always #5 clk = ~clk;
@@ -77,7 +77,7 @@ module MEM_WB_Register_tb;
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
         #10;
         
         // Test 1
@@ -90,14 +90,14 @@ module MEM_WB_Register_tb;
         MEM_register_write_enable        = 1'b1;            // Register Write Enable
         MEM_csr_write_enable             = 1'b0;
         MEM_rd                           = 5'b00110;
-        MEM_register_file_write_data     = 32'h0000_000A;   // Dummy BERF_WD data value
+        MEM_byte_enable_logic_register_file_write_data     = 32'h0000_000A;   // Dummy BERF_WD data value
 
         @(posedge clk); #1;
         $display("Test 1: Previous value should be output now");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
         
         // Test 2@(posedge clk); #1;
         @(posedge clk); #1;
@@ -105,7 +105,7 @@ module MEM_WB_Register_tb;
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         // Test 3
         @(negedge clk); 
@@ -117,19 +117,19 @@ module MEM_WB_Register_tb;
         MEM_register_write_enable        = 1'b1;
         MEM_csr_write_enable             = 1'b0;
         MEM_rd                           = 5'b00111;
-        MEM_register_file_write_data     = 32'hDEAD_BEEF;   // Dummy BERF_WD data value
+        MEM_byte_enable_logic_register_file_write_data     = 32'hDEAD_BEEF;   // Dummy BERF_WD data value
         $display("Test 3-1: new input now(should be same)");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         @(posedge clk); #1;
         $display("Test 3-2: Test 3-1 input should be output now \n");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         flush = 1'b1; #10;
         flush = 1'b0;
@@ -139,7 +139,7 @@ module MEM_WB_Register_tb;
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         MEM_pc_plus_4                    = 32'h0000_000C;
         MEM_register_file_write_data_select = 3'b011;       // CSR read → Register File
@@ -149,18 +149,18 @@ module MEM_WB_Register_tb;
         MEM_register_write_enable        = 1'b1;            // rd ← CSR
         MEM_csr_write_enable             = 1'b1;            // CSR write enable
         MEM_rd                           = 5'b10001;
-        MEM_register_file_write_data     = 32'hCAFE_BABE;   // Dummy BERF_WD data value
+        MEM_byte_enable_logic_register_file_write_data     = 32'hCAFE_BABE;   // Dummy BERF_WD data value
         $display("Test 5-1: Input begin (should be same)");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
         #10;
         $display("Test 5-2: Test 5-1's input should be output now");
         $display("|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |");
         $display("|   %h   |      %b     |         %b         |         %b         |", WB_pc_plus_4, WB_register_file_write_data_select, WB_csr_write_enable, WB_register_write_enable);
         $display("|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |");
-        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
+        $display("|   %h   |  %h  |   %h    |    %h    |  %b  |\n", WB_byte_enable_logic_register_file_write_data, WB_imm, WB_csr_read_data, WB_alu_result, WB_rd);
 
         $display("\n====================  MEM_WB_Register Test END  ====================");
 

--- a/RV32I/testbenches/results/MEM_WB_Register_result.vvp
+++ b/RV32I/testbenches/results/MEM_WB_Register_result.vvp
@@ -7,33 +7,33 @@
 :vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
 :vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
 :vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
-S_0000025acd5ec190 .scope module, "MEM_WB_Register_tb" "MEM_WB_Register_tb" 2 3;
+S_0000023f0faec190 .scope module, "MEM_WB_Register_tb" "MEM_WB_Register_tb" 2 3;
  .timescale -9 -12;
-P_0000025acd617d00 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
-v0000025acd6853c0_0 .var "MEM_alu_result", 31 0;
-v0000025acd685320_0 .var "MEM_csr_read_data", 31 0;
-v0000025acd685820_0 .var "MEM_csr_write_enable", 0 0;
-v0000025acd685460_0 .var "MEM_imm", 31 0;
-v0000025acd684e20_0 .var "MEM_pc_plus_4", 31 0;
-v0000025acd685500_0 .var "MEM_rd", 4 0;
-v0000025acd6856e0_0 .var "MEM_register_file_write_data", 31 0;
-v0000025acd684f60_0 .var "MEM_register_file_write_data_select", 2 0;
-v0000025acd685000_0 .var "MEM_register_write_enable", 0 0;
-v0000025acd685140_0 .net "WB_alu_result", 31 0, v0000025acd5a68d0_0;  1 drivers
-v0000025acd6851e0_0 .net "WB_csr_read_data", 31 0, v0000025acd684c40_0;  1 drivers
-v0000025acd6855a0_0 .net "WB_csr_write_enable", 0 0, v0000025acd684ec0_0;  1 drivers
-v0000025acd685640_0 .net "WB_imm", 31 0, v0000025acd685960_0;  1 drivers
-v0000025acd685780_0 .net "WB_pc_plus_4", 31 0, v0000025acd684ba0_0;  1 drivers
-v0000025acd6861f0_0 .net "WB_rd", 4 0, v0000025acd685280_0;  1 drivers
-v0000025acd687050_0 .net "WB_register_file_write_data", 31 0, v0000025acd685a00_0;  1 drivers
-v0000025acd687870_0 .net "WB_register_file_write_data_select", 2 0, v0000025acd684b00_0;  1 drivers
-v0000025acd685cf0_0 .net "WB_register_write_enable", 0 0, v0000025acd6858c0_0;  1 drivers
-v0000025acd686970_0 .var "clk", 0 0;
-v0000025acd6868d0_0 .var "flush", 0 0;
-v0000025acd6879b0_0 .var "reset", 0 0;
-E_0000025acd617a00 .event posedge, v0000025acd684ce0_0;
-E_0000025acd617580 .event negedge, v0000025acd684ce0_0;
-S_0000025acd5ec320 .scope module, "mem_wb_register" "MEM_WB_Register" 2 36, 3 1 0, S_0000025acd5ec190;
+P_0000023f0fb16f80 .param/l "XLEN" 1 2 4, +C4<00000000000000000000000000100000>;
+v0000023f0fb85500_0 .var "MEM_alu_result", 31 0;
+v0000023f0fb84ce0_0 .var "MEM_byte_enable_logic_register_file_write_data", 31 0;
+v0000023f0fb858c0_0 .var "MEM_csr_read_data", 31 0;
+v0000023f0fb84ec0_0 .var "MEM_csr_write_enable", 0 0;
+v0000023f0fb85960_0 .var "MEM_imm", 31 0;
+v0000023f0fb855a0_0 .var "MEM_pc_plus_4", 31 0;
+v0000023f0fb85640_0 .var "MEM_rd", 4 0;
+v0000023f0fb84f60_0 .var "MEM_register_file_write_data_select", 2 0;
+v0000023f0fb85a00_0 .var "MEM_register_write_enable", 0 0;
+v0000023f0fb85140_0 .net "WB_alu_result", 31 0, v0000023f0faa68d0_0;  1 drivers
+v0000023f0fb856e0_0 .net "WB_byte_enable_logic_register_file_write_data", 31 0, v0000023f0fb853c0_0;  1 drivers
+v0000023f0fb85780_0 .net "WB_csr_read_data", 31 0, v0000023f0fb850a0_0;  1 drivers
+v0000023f0fb85280_0 .net "WB_csr_write_enable", 0 0, v0000023f0fb84c40_0;  1 drivers
+v0000023f0fb85000_0 .net "WB_imm", 31 0, v0000023f0fb85820_0;  1 drivers
+v0000023f0fb85e30_0 .net "WB_pc_plus_4", 31 0, v0000023f0fb84e20_0;  1 drivers
+v0000023f0fb87190_0 .net "WB_rd", 4 0, v0000023f0fb84d80_0;  1 drivers
+v0000023f0fb87370_0 .net "WB_register_file_write_data_select", 2 0, v0000023f0fb84b00_0;  1 drivers
+v0000023f0fb868d0_0 .net "WB_register_write_enable", 0 0, v0000023f0fb851e0_0;  1 drivers
+v0000023f0fb860b0_0 .var "clk", 0 0;
+v0000023f0fb879b0_0 .var "flush", 0 0;
+v0000023f0fb86290_0 .var "reset", 0 0;
+E_0000023f0fb16a40 .event posedge, v0000023f0fb85320_0;
+E_0000023f0fb167c0 .event negedge, v0000023f0fb85320_0;
+S_0000023f0faec320 .scope module, "mem_wb_register" "MEM_WB_Register" 2 36, 3 1 0, S_0000023f0faec190;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "reset";
@@ -46,7 +46,7 @@ S_0000025acd5ec320 .scope module, "mem_wb_register" "MEM_WB_Register" 2 36, 3 1 
     .port_info 8 /INPUT 1 "MEM_register_write_enable";
     .port_info 9 /INPUT 1 "MEM_csr_write_enable";
     .port_info 10 /INPUT 5 "MEM_rd";
-    .port_info 11 /INPUT 32 "MEM_register_file_write_data";
+    .port_info 11 /INPUT 32 "MEM_byte_enable_logic_register_file_write_data";
     .port_info 12 /OUTPUT 32 "WB_pc_plus_4";
     .port_info 13 /OUTPUT 3 "WB_register_file_write_data_select";
     .port_info 14 /OUTPUT 32 "WB_imm";
@@ -55,220 +55,220 @@ S_0000025acd5ec320 .scope module, "mem_wb_register" "MEM_WB_Register" 2 36, 3 1 
     .port_info 17 /OUTPUT 1 "WB_register_write_enable";
     .port_info 18 /OUTPUT 1 "WB_csr_write_enable";
     .port_info 19 /OUTPUT 5 "WB_rd";
-    .port_info 20 /OUTPUT 32 "WB_register_file_write_data";
-P_0000025acd6171c0 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
-v0000025acd5eb2f0_0 .net "MEM_alu_result", 31 0, v0000025acd6853c0_0;  1 drivers
-v0000025acd5e9e60_0 .net "MEM_csr_read_data", 31 0, v0000025acd685320_0;  1 drivers
-v0000025acd5a6fa0_0 .net "MEM_csr_write_enable", 0 0, v0000025acd685820_0;  1 drivers
-v0000025acd5f9060_0 .net "MEM_imm", 31 0, v0000025acd685460_0;  1 drivers
-v0000025acd621320_0 .net "MEM_pc_plus_4", 31 0, v0000025acd684e20_0;  1 drivers
-v0000025acd5f20e0_0 .net "MEM_rd", 4 0, v0000025acd685500_0;  1 drivers
-v0000025acd5f2180_0 .net "MEM_register_file_write_data", 31 0, v0000025acd6856e0_0;  1 drivers
-v0000025acd5f2220_0 .net "MEM_register_file_write_data_select", 2 0, v0000025acd684f60_0;  1 drivers
-v0000025acd5f22c0_0 .net "MEM_register_write_enable", 0 0, v0000025acd685000_0;  1 drivers
-v0000025acd5a68d0_0 .var "WB_alu_result", 31 0;
-v0000025acd684c40_0 .var "WB_csr_read_data", 31 0;
-v0000025acd684ec0_0 .var "WB_csr_write_enable", 0 0;
-v0000025acd685960_0 .var "WB_imm", 31 0;
-v0000025acd684ba0_0 .var "WB_pc_plus_4", 31 0;
-v0000025acd685280_0 .var "WB_rd", 4 0;
-v0000025acd685a00_0 .var "WB_register_file_write_data", 31 0;
-v0000025acd684b00_0 .var "WB_register_file_write_data_select", 2 0;
-v0000025acd6858c0_0 .var "WB_register_write_enable", 0 0;
-v0000025acd684ce0_0 .net "clk", 0 0, v0000025acd686970_0;  1 drivers
-v0000025acd6850a0_0 .net "flush", 0 0, v0000025acd6868d0_0;  1 drivers
-v0000025acd684d80_0 .net "reset", 0 0, v0000025acd6879b0_0;  1 drivers
-E_0000025acd6176c0 .event posedge, v0000025acd684d80_0, v0000025acd684ce0_0;
-    .scope S_0000025acd5ec320;
+    .port_info 20 /OUTPUT 32 "WB_byte_enable_logic_register_file_write_data";
+P_0000023f0fb16a80 .param/l "XLEN" 0 3 2, +C4<00000000000000000000000000100000>;
+v0000023f0faeb2f0_0 .net "MEM_alu_result", 31 0, v0000023f0fb85500_0;  1 drivers
+v0000023f0fae9e60_0 .net "MEM_byte_enable_logic_register_file_write_data", 31 0, v0000023f0fb84ce0_0;  1 drivers
+v0000023f0faa6fa0_0 .net "MEM_csr_read_data", 31 0, v0000023f0fb858c0_0;  1 drivers
+v0000023f0faf9060_0 .net "MEM_csr_write_enable", 0 0, v0000023f0fb84ec0_0;  1 drivers
+v0000023f0fb21320_0 .net "MEM_imm", 31 0, v0000023f0fb85960_0;  1 drivers
+v0000023f0faf20e0_0 .net "MEM_pc_plus_4", 31 0, v0000023f0fb855a0_0;  1 drivers
+v0000023f0faf2180_0 .net "MEM_rd", 4 0, v0000023f0fb85640_0;  1 drivers
+v0000023f0faf2220_0 .net "MEM_register_file_write_data_select", 2 0, v0000023f0fb84f60_0;  1 drivers
+v0000023f0faf22c0_0 .net "MEM_register_write_enable", 0 0, v0000023f0fb85a00_0;  1 drivers
+v0000023f0faa68d0_0 .var "WB_alu_result", 31 0;
+v0000023f0fb853c0_0 .var "WB_byte_enable_logic_register_file_write_data", 31 0;
+v0000023f0fb850a0_0 .var "WB_csr_read_data", 31 0;
+v0000023f0fb84c40_0 .var "WB_csr_write_enable", 0 0;
+v0000023f0fb85820_0 .var "WB_imm", 31 0;
+v0000023f0fb84e20_0 .var "WB_pc_plus_4", 31 0;
+v0000023f0fb84d80_0 .var "WB_rd", 4 0;
+v0000023f0fb84b00_0 .var "WB_register_file_write_data_select", 2 0;
+v0000023f0fb851e0_0 .var "WB_register_write_enable", 0 0;
+v0000023f0fb85320_0 .net "clk", 0 0, v0000023f0fb860b0_0;  1 drivers
+v0000023f0fb84ba0_0 .net "flush", 0 0, v0000023f0fb879b0_0;  1 drivers
+v0000023f0fb85460_0 .net "reset", 0 0, v0000023f0fb86290_0;  1 drivers
+E_0000023f0fb16700 .event posedge, v0000023f0fb85460_0, v0000023f0fb85320_0;
+    .scope S_0000023f0faec320;
 T_0 ;
-    %wait E_0000025acd6176c0;
-    %load/vec4 v0000025acd684d80_0;
+    %wait E_0000023f0fb16700;
+    %load/vec4 v0000023f0fb85460_0;
     %flag_set/vec4 8;
     %jmp/1 T_0.2, 8;
-    %load/vec4 v0000025acd6850a0_0;
+    %load/vec4 v0000023f0fb84ba0_0;
     %flag_set/vec4 9;
     %flag_or 8, 9;
 T_0.2;
     %jmp/0xz  T_0.0, 8;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000025acd684ba0_0, 0;
+    %assign/vec4 v0000023f0fb84e20_0, 0;
     %pushi/vec4 0, 0, 3;
-    %assign/vec4 v0000025acd684b00_0, 0;
+    %assign/vec4 v0000023f0fb84b00_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000025acd685960_0, 0;
+    %assign/vec4 v0000023f0fb85820_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000025acd684c40_0, 0;
+    %assign/vec4 v0000023f0fb850a0_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000025acd5a68d0_0, 0;
+    %assign/vec4 v0000023f0faa68d0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000025acd6858c0_0, 0;
+    %assign/vec4 v0000023f0fb851e0_0, 0;
     %pushi/vec4 0, 0, 1;
-    %assign/vec4 v0000025acd684ec0_0, 0;
+    %assign/vec4 v0000023f0fb84c40_0, 0;
     %pushi/vec4 0, 0, 5;
-    %assign/vec4 v0000025acd685280_0, 0;
+    %assign/vec4 v0000023f0fb84d80_0, 0;
     %pushi/vec4 0, 0, 32;
-    %assign/vec4 v0000025acd685a00_0, 0;
+    %assign/vec4 v0000023f0fb853c0_0, 0;
     %jmp T_0.1;
 T_0.0 ;
-    %load/vec4 v0000025acd621320_0;
-    %assign/vec4 v0000025acd684ba0_0, 0;
-    %load/vec4 v0000025acd5f2220_0;
-    %assign/vec4 v0000025acd684b00_0, 0;
-    %load/vec4 v0000025acd5f9060_0;
-    %assign/vec4 v0000025acd685960_0, 0;
-    %load/vec4 v0000025acd5e9e60_0;
-    %assign/vec4 v0000025acd684c40_0, 0;
-    %load/vec4 v0000025acd5eb2f0_0;
-    %assign/vec4 v0000025acd5a68d0_0, 0;
-    %load/vec4 v0000025acd5f22c0_0;
-    %assign/vec4 v0000025acd6858c0_0, 0;
-    %load/vec4 v0000025acd5a6fa0_0;
-    %assign/vec4 v0000025acd684ec0_0, 0;
-    %load/vec4 v0000025acd5f20e0_0;
-    %assign/vec4 v0000025acd685280_0, 0;
-    %load/vec4 v0000025acd5f2180_0;
-    %assign/vec4 v0000025acd685a00_0, 0;
+    %load/vec4 v0000023f0faf20e0_0;
+    %assign/vec4 v0000023f0fb84e20_0, 0;
+    %load/vec4 v0000023f0faf2220_0;
+    %assign/vec4 v0000023f0fb84b00_0, 0;
+    %load/vec4 v0000023f0fb21320_0;
+    %assign/vec4 v0000023f0fb85820_0, 0;
+    %load/vec4 v0000023f0faa6fa0_0;
+    %assign/vec4 v0000023f0fb850a0_0, 0;
+    %load/vec4 v0000023f0faeb2f0_0;
+    %assign/vec4 v0000023f0faa68d0_0, 0;
+    %load/vec4 v0000023f0faf22c0_0;
+    %assign/vec4 v0000023f0fb851e0_0, 0;
+    %load/vec4 v0000023f0faf9060_0;
+    %assign/vec4 v0000023f0fb84c40_0, 0;
+    %load/vec4 v0000023f0faf2180_0;
+    %assign/vec4 v0000023f0fb84d80_0, 0;
+    %load/vec4 v0000023f0fae9e60_0;
+    %assign/vec4 v0000023f0fb853c0_0, 0;
 T_0.1 ;
     %jmp T_0;
     .thread T_0;
-    .scope S_0000025acd5ec190;
+    .scope S_0000023f0faec190;
 T_1 ;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000025acd686970_0, 0, 1;
+    %store/vec4 v0000023f0fb860b0_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000025acd6879b0_0, 0, 1;
+    %store/vec4 v0000023f0fb86290_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000025acd6868d0_0, 0, 1;
+    %store/vec4 v0000023f0fb879b0_0, 0, 1;
     %end;
     .thread T_1;
-    .scope S_0000025acd5ec190;
+    .scope S_0000023f0faec190;
 T_2 ;
     %delay 5000, 0;
-    %load/vec4 v0000025acd686970_0;
+    %load/vec4 v0000023f0fb860b0_0;
     %inv;
-    %store/vec4 v0000025acd686970_0, 0, 1;
+    %store/vec4 v0000023f0fb860b0_0, 0, 1;
     %jmp T_2;
     .thread T_2;
-    .scope S_0000025acd5ec190;
+    .scope S_0000023f0faec190;
 T_3 ;
     %vpi_call 2 65 "$dumpfile", "testbenches/results/waveforms/MEM_WB_Register_tb_result.vcd" {0 0 0};
-    %vpi_call 2 66 "$dumpvars", 32'sb00000000000000000000000000000000, S_0000025acd5ec320 {0 0 0};
+    %vpi_call 2 66 "$dumpvars", 32'sb00000000000000000000000000000000, S_0000023f0faec320 {0 0 0};
     %vpi_call 2 69 "$display", "==================== MEM_WB_Register Test START ====================\012" {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000025acd6879b0_0, 0, 1;
+    %store/vec4 v0000023f0fb86290_0, 0, 1;
     %delay 30000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000025acd6879b0_0, 0, 1;
-    %wait E_0000025acd617a00;
+    %store/vec4 v0000023f0fb86290_0, 0, 1;
+    %wait E_0000023f0fb16a40;
     %vpi_call 2 76 "$display", "Input now" {0 0 0};
     %vpi_call 2 77 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 78 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 78 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 79 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 80 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %vpi_call 2 80 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
     %delay 10000, 0;
-    %wait E_0000025acd617580;
+    %wait E_0000023f0fb167c0;
     %pushi/vec4 4, 0, 32;
-    %store/vec4 v0000025acd684e20_0, 0, 32;
+    %store/vec4 v0000023f0fb855a0_0, 0, 32;
     %pushi/vec4 2, 0, 3;
-    %store/vec4 v0000025acd684f60_0, 0, 3;
+    %store/vec4 v0000023f0fb84f60_0, 0, 3;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000025acd685460_0, 0, 32;
+    %store/vec4 v0000023f0fb85960_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000025acd685320_0, 0, 32;
+    %store/vec4 v0000023f0fb858c0_0, 0, 32;
     %pushi/vec4 11, 0, 32;
-    %store/vec4 v0000025acd6853c0_0, 0, 32;
+    %store/vec4 v0000023f0fb85500_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000025acd685000_0, 0, 1;
+    %store/vec4 v0000023f0fb85a00_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000025acd685820_0, 0, 1;
+    %store/vec4 v0000023f0fb84ec0_0, 0, 1;
     %pushi/vec4 6, 0, 5;
-    %store/vec4 v0000025acd685500_0, 0, 5;
+    %store/vec4 v0000023f0fb85640_0, 0, 5;
     %pushi/vec4 10, 0, 32;
-    %store/vec4 v0000025acd6856e0_0, 0, 32;
-    %wait E_0000025acd617a00;
+    %store/vec4 v0000023f0fb84ce0_0, 0, 32;
+    %wait E_0000023f0fb16a40;
     %delay 1000, 0;
     %vpi_call 2 96 "$display", "Test 1: Previous value should be output now" {0 0 0};
     %vpi_call 2 97 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 98 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 98 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 99 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 100 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
-    %wait E_0000025acd617a00;
+    %vpi_call 2 100 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
+    %wait E_0000023f0fb16a40;
     %delay 1000, 0;
     %vpi_call 2 104 "$display", "Test 2: No input(should be same)" {0 0 0};
     %vpi_call 2 105 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 106 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 106 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 107 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 108 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
-    %wait E_0000025acd617580;
+    %vpi_call 2 108 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
+    %wait E_0000023f0fb167c0;
     %pushi/vec4 8, 0, 32;
-    %store/vec4 v0000025acd684e20_0, 0, 32;
+    %store/vec4 v0000023f0fb855a0_0, 0, 32;
     %pushi/vec4 1, 0, 3;
-    %store/vec4 v0000025acd684f60_0, 0, 3;
+    %store/vec4 v0000023f0fb84f60_0, 0, 3;
     %pushi/vec4 32, 0, 32;
-    %store/vec4 v0000025acd685460_0, 0, 32;
+    %store/vec4 v0000023f0fb85960_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000025acd685320_0, 0, 32;
+    %store/vec4 v0000023f0fb858c0_0, 0, 32;
     %pushi/vec4 268435488, 0, 32;
-    %store/vec4 v0000025acd6853c0_0, 0, 32;
+    %store/vec4 v0000023f0fb85500_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000025acd685000_0, 0, 1;
+    %store/vec4 v0000023f0fb85a00_0, 0, 1;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000025acd685820_0, 0, 1;
+    %store/vec4 v0000023f0fb84ec0_0, 0, 1;
     %pushi/vec4 7, 0, 5;
-    %store/vec4 v0000025acd685500_0, 0, 5;
+    %store/vec4 v0000023f0fb85640_0, 0, 5;
     %pushi/vec4 3735928559, 0, 32;
-    %store/vec4 v0000025acd6856e0_0, 0, 32;
+    %store/vec4 v0000023f0fb84ce0_0, 0, 32;
     %vpi_call 2 121 "$display", "Test 3-1: new input now(should be same)" {0 0 0};
     %vpi_call 2 122 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 123 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 123 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 124 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 125 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
-    %wait E_0000025acd617a00;
+    %vpi_call 2 125 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
+    %wait E_0000023f0fb16a40;
     %delay 1000, 0;
     %vpi_call 2 128 "$display", "Test 3-2: Test 3-1 input should be output now \012" {0 0 0};
     %vpi_call 2 129 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 130 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 130 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 131 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 132 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %vpi_call 2 132 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000025acd6868d0_0, 0, 1;
+    %store/vec4 v0000023f0fb879b0_0, 0, 1;
     %delay 10000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0000025acd6868d0_0, 0, 1;
+    %store/vec4 v0000023f0fb879b0_0, 0, 1;
     %vpi_call 2 138 "$display", "Test 4: Flushed (should be NOP and zero)" {0 0 0};
     %vpi_call 2 139 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 140 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 140 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 141 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 142 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %vpi_call 2 142 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
     %pushi/vec4 12, 0, 32;
-    %store/vec4 v0000025acd684e20_0, 0, 32;
+    %store/vec4 v0000023f0fb855a0_0, 0, 32;
     %pushi/vec4 3, 0, 3;
-    %store/vec4 v0000025acd684f60_0, 0, 3;
+    %store/vec4 v0000023f0fb84f60_0, 0, 3;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000025acd685460_0, 0, 32;
+    %store/vec4 v0000023f0fb85960_0, 0, 32;
     %pushi/vec4 3405691582, 0, 32;
-    %store/vec4 v0000025acd685320_0, 0, 32;
+    %store/vec4 v0000023f0fb858c0_0, 0, 32;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0000025acd6853c0_0, 0, 32;
+    %store/vec4 v0000023f0fb85500_0, 0, 32;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000025acd685000_0, 0, 1;
+    %store/vec4 v0000023f0fb85a00_0, 0, 1;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0000025acd685820_0, 0, 1;
+    %store/vec4 v0000023f0fb84ec0_0, 0, 1;
     %pushi/vec4 17, 0, 5;
-    %store/vec4 v0000025acd685500_0, 0, 5;
+    %store/vec4 v0000023f0fb85640_0, 0, 5;
     %pushi/vec4 3405691582, 0, 32;
-    %store/vec4 v0000025acd6856e0_0, 0, 32;
+    %store/vec4 v0000023f0fb84ce0_0, 0, 32;
     %vpi_call 2 153 "$display", "Test 5-1: Input begin (should be same)" {0 0 0};
     %vpi_call 2 154 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 155 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 155 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 156 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 157 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %vpi_call 2 157 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
     %delay 10000, 0;
     %vpi_call 2 159 "$display", "Test 5-2: Test 5-1's input should be output now" {0 0 0};
     %vpi_call 2 160 "$display", "|     PC+4     | RF_WD select |  CSR Write Enable | RegF Write Enable |" {0 0 0};
-    %vpi_call 2 161 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000025acd685780_0, v0000025acd687870_0, v0000025acd6855a0_0, v0000025acd685cf0_0 {0 0 0};
+    %vpi_call 2 161 "$display", "|   %h   |      %b     |         %b         |         %b         |", v0000023f0fb85e30_0, v0000023f0fb87370_0, v0000023f0fb85280_0, v0000023f0fb868d0_0 {0 0 0};
     %vpi_call 2 162 "$display", "|    BERF_WD   |     imm    | csr_read_data |   ALU result   |   rd   |" {0 0 0};
-    %vpi_call 2 163 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000025acd687050_0, v0000025acd685640_0, v0000025acd6851e0_0, v0000025acd685140_0, v0000025acd6861f0_0 {0 0 0};
+    %vpi_call 2 163 "$display", "|   %h   |  %h  |   %h    |    %h    |  %b  |\012", v0000023f0fb856e0_0, v0000023f0fb85000_0, v0000023f0fb85780_0, v0000023f0fb85140_0, v0000023f0fb87190_0 {0 0 0};
     %vpi_call 2 165 "$display", "\012====================  MEM_WB_Register Test END  ====================" {0 0 0};
     %vpi_call 2 167 "$stop" {0 0 0};
     %end;

--- a/RV32I/testbenches/results/waveforms/MEM_WB_Register_tb_result.vcd
+++ b/RV32I/testbenches/results/waveforms/MEM_WB_Register_tb_result.vcd
@@ -1,5 +1,5 @@
 $date
-	Fri May 23 23:48:57 2025
+	Sun May 25 20:15:55 2025
 $end
 $version
 	Icarus Verilog
@@ -10,12 +10,12 @@ $end
 $scope module MEM_WB_Register_tb $end
 $scope module mem_wb_register $end
 $var wire 32 ! MEM_alu_result [31:0] $end
-$var wire 32 " MEM_csr_read_data [31:0] $end
-$var wire 1 # MEM_csr_write_enable $end
-$var wire 32 $ MEM_imm [31:0] $end
-$var wire 32 % MEM_pc_plus_4 [31:0] $end
-$var wire 5 & MEM_rd [4:0] $end
-$var wire 32 ' MEM_register_file_write_data [31:0] $end
+$var wire 32 " MEM_byte_enable_logic_register_file_write_data [31:0] $end
+$var wire 32 # MEM_csr_read_data [31:0] $end
+$var wire 1 $ MEM_csr_write_enable $end
+$var wire 32 % MEM_imm [31:0] $end
+$var wire 32 & MEM_pc_plus_4 [31:0] $end
+$var wire 5 ' MEM_rd [4:0] $end
 $var wire 3 ( MEM_register_file_write_data_select [2:0] $end
 $var wire 1 ) MEM_register_write_enable $end
 $var wire 1 * clk $end
@@ -23,12 +23,12 @@ $var wire 1 + flush $end
 $var wire 1 , reset $end
 $var parameter 32 - XLEN $end
 $var reg 32 . WB_alu_result [31:0] $end
-$var reg 32 / WB_csr_read_data [31:0] $end
-$var reg 1 0 WB_csr_write_enable $end
-$var reg 32 1 WB_imm [31:0] $end
-$var reg 32 2 WB_pc_plus_4 [31:0] $end
-$var reg 5 3 WB_rd [4:0] $end
-$var reg 32 4 WB_register_file_write_data [31:0] $end
+$var reg 32 / WB_byte_enable_logic_register_file_write_data [31:0] $end
+$var reg 32 0 WB_csr_read_data [31:0] $end
+$var reg 1 1 WB_csr_write_enable $end
+$var reg 32 2 WB_imm [31:0] $end
+$var reg 32 3 WB_pc_plus_4 [31:0] $end
+$var reg 5 4 WB_rd [4:0] $end
 $var reg 3 5 WB_register_file_write_data_select [2:0] $end
 $var reg 1 6 WB_register_write_enable $end
 $upscope $end
@@ -45,8 +45,8 @@ b0 5
 b0 4
 b0 3
 b0 2
-b0 1
-00
+01
+b0 0
 b0 /
 b0 .
 1,
@@ -57,8 +57,8 @@ bx (
 bx '
 bx &
 bx %
-bx $
-x#
+x$
+bx #
 bx "
 bx !
 $end
@@ -76,94 +76,94 @@ $end
 0*
 0,
 #35000
+bx /
 bx 4
-bx 3
-x0
+x1
 x6
 bx .
-bx /
-bx 1
-bx 5
+bx 0
 bx 2
+bx 5
+bx 3
 1*
 #40000
 0*
 #45000
 1*
 #50000
-b1010 '
-b110 &
-0#
+b1010 "
+b110 '
+0$
 1)
 b1011 !
-b0 "
-b0 $
+b0 #
+b0 %
 b10 (
-b100 %
+b100 &
 0*
 #55000
-b1010 4
-b110 3
-00
+b1010 /
+b110 4
+01
 16
 b1011 .
-b0 /
-b0 1
+b0 0
+b0 2
 b10 5
-b100 2
+b100 3
 1*
 #60000
 0*
 #65000
 1*
 #70000
-b11011110101011011011111011101111 '
-b111 &
+b11011110101011011011111011101111 "
+b111 '
 b10000000000000000000000100000 !
-b100000 $
+b100000 %
 b1 (
-b1000 %
+b1000 &
 0*
 #75000
-b11011110101011011011111011101111 4
-b111 3
+b11011110101011011011111011101111 /
+b111 4
 b10000000000000000000000100000 .
-b100000 1
+b100000 2
 b1 5
-b1000 2
+b1000 3
 1*
 #76000
 1+
 #80000
 0*
 #85000
+b0 /
 b0 4
-b0 3
 06
 b0 .
-b0 1
-b0 5
 b0 2
+b0 5
+b0 3
 1*
 #86000
-b11001010111111101011101010111110 '
-b10001 &
-1#
-b0 !
 b11001010111111101011101010111110 "
-b0 $
+b10001 '
+1$
+b0 !
+b11001010111111101011101010111110 #
+b0 %
 b11 (
-b1100 %
+b1100 &
 0+
 #90000
 0*
 #95000
-b11001010111111101011101010111110 4
-b10001 3
-10
-16
 b11001010111111101011101010111110 /
+b10001 4
+11
+16
+b11001010111111101011101010111110 0
 b11 5
-b1100 2
+b1100 3
 1*
 #96000


### PR DESCRIPTION
Revised existing `MEM_register_file_write_data`, `WB_register_file_write_data` to 
`MEM_byte_enable_logic_register_file_write_data`, `WB_byte_enable_logic_register_file_write_data` for **RV32I46F_5SP** top-module implementation.