### PR TITLE
[Feat] Revise Trap Controller latch infer issue and multi-driven issue

### DIFF
--- a/RV32I/modules/Trap_Controller.v
+++ b/RV32I/modules/Trap_Controller.v
@@ -25,14 +25,18 @@ localparam  IDLE          = 2'b00,
 
 // traditional FSM state architecture
 reg [1:0] trap_handle_state, next_trap_handle_state;
+reg debug_mode_enable;
 
 // FSM update logic and debug_mode reset
 always @(posedge clk or posedge reset) begin
     if (reset) begin
         trap_handle_state <= IDLE;
-        debug_mode <= 1'b0; 
+        debug_mode_enable <= 1'b0;
     end 
-    else trap_handle_state <= next_trap_handle_state;
+    else begin
+        trap_handle_state <= next_trap_handle_state;
+        debug_mode_enable <= debug_mode;
+    end
 end
 
 always @(*) begin
@@ -45,7 +49,8 @@ always @(*) begin
     trap_done            = 1'b1;
     // default next state
     next_trap_handle_state = IDLE;
-
+    debug_mode = debug_mode_enable;
+    
     case (trap_status)
         // traps that doesn't require multiple PTH FSM
         `TRAP_NONE: begin


### PR DESCRIPTION
## Revised Trap Controller for FPGA implementation
The original `debug_mode` signal in the **Trap Controller** module had a ***multi-driven issue*** due to being assigned from both _sequential_ and _combinational logic_ blocks. This issue was detected by the **Vivado linter**. To resolve this, the reset logic previously initializing `debug_mode` to 0 within _sequential logic_ has been separated into a distinct `debug_mode_enable` signal. This modification also addresses the ***latch inferring issue***.