### PR TITLE
[Feat] Revise Exception Detector to separately handle MISALIGNED STORE and LOAD exceptions

### DIFF
--- a/RV32I/modules/Exception_Detector.v
+++ b/RV32I/modules/Exception_Detector.v
@@ -1,79 +1,178 @@
 `include "modules/headers/opcode.vh"
+`include "modules/headers/store.vh"
+`include "modules/headers/load.vh"
 `include "modules/headers/trap.vh"
 
 module ExceptionDetector (
-	input [6:0] ID_opcode,			// opcode from ID Phase
-	input [6:0] EX_opcode,			// opcode from EX Phase
-	input [2:0] funct3,				// funct3
-	input [11:0] funct12,			// raw_imm field to distinguish EBREAK, ECALL and MRET
-	input [1:0] jump_target_lsbs,		// LSBs of jump target
-	input [1:0] branch_target_lsbs,		// LSBs of branch target
-	input branch_estimation,
-	input misalinged_memory,		// misalinged detection from BE_Logic
-	
-    output reg trapped,				// signal indicating if trap has occurred
-	output reg [2:0] trap_status	// current trap status
+    input [6:0] ID_opcode,            // opcode from ID Phase
+    input [6:0] EX_opcode,            // opcode from EX Phase
+    // input [4:0] rs1,                   // For Illegal Instruction Exception
+    input [2:0] ID_funct3,                // funct3
+    input [2:0] EX_funct3,
+    input [1:0] alu_result,         // LSBs of jump target and data_memory_address
+    input [11:0] raw_imm,            // raw_imm field to distinguish EBREAK, ECALL and MRET, CSR_Address
+    input csr_write_enable,         // CSR WE signal from Control Unit for Detecting Illegal CSR access from ID Phase.
+    input [1:0] branch_target_lsbs,        // LSBs of branch target
+    input branch_estimation,
+    
+    output reg trapped,                // signal indicating if trap has occurred
+    output reg [2:0] trap_status    // current trap status
 );
-	
-	always @(*) begin
-		case (ID_opcode)
-			`OPCODE_FENCE: begin	// Zifence
-				if (funct3 == 3'b001) begin
-					trapped = 1'b1;
-					trap_status = `TRAP_FENCEI;
-				end
-			end
+    reg ID_trapped;
+    reg [2:0] ID_trap_status;
+    reg EX_trapped;
+    reg [2:0] EX_trap_status;
 
-			`OPCODE_ENVIRONMENT: begin // EBREAK, ECALL, MRET
-				if (funct3 == 3'b0) begin
-						trapped = 1;
-					if (funct12 == 12'b0011_0000_0010) begin
-						trap_status = `TRAP_MRET;
-					end
-					else if (funct12[0]) begin
-						trap_status = `TRAP_EBREAK;
-					end
-					else if (funct12 == 12'b0) begin
-						trap_status = `TRAP_ECALL;
-					end
-				end
-				else begin
-					trapped = 0;
-					trap_status = `TRAP_NONE;
-				end
-			end
-			`OPCODE_BRANCH: begin // Misaligned
-			if (branch_estimation == 1'b1) begin
-				if (branch_target_lsbs == 2'b0) begin
-					trapped = 0;
-					trap_status = `TRAP_NONE;
-				end 
-				else begin
-					trapped = 1;
-					trap_status = `TRAP_MISALIGNED_INSTRUCTION;
-				end
-			end
-			end
-			default: begin
-				trapped = 0;
-				trap_status = `TRAP_NONE;
-			end
+
+    /* For Illegal Instruction Exception
+    wire csr_write;
+    assign csr_write = (ID_funct3 == `CSR_CSRRW || ID_funct3 == `CSR_CSRRWI) 
+                    || ((ID_funct3 == `CSR_CSRRS || ID_funct3 == `CSR_CSRRSI) && (rs1 != 5'b0))
+                    || ((ID_funct3 == `CSR_CSRRC || ID_funct3 == `CSR_CSRRCI) && (rs1 != 5'b0));
+
+    wire valid_write_csr;
+    assign valid_write_csr = (raw_imm == 12'h305) ||
+                             (raw_imm == 12'h341) ||
+                             (raw_imm == 12'h342);
+*/
+    always @(*) begin
+        ID_trap_status = `TRAP_NONE;
+        ID_trapped = 1'b0;
+
+        case (ID_opcode)
+            `OPCODE_FENCE: begin    // Zifence
+                if (ID_funct3 == 3'b001) begin
+                    ID_trapped = 1'b1;
+                    ID_trap_status = `TRAP_FENCEI;
+                end
+            end
+
+            `OPCODE_ENVIRONMENT: begin // EBREAK, ECALL, MRET
+                if (ID_funct3 == 3'b0) begin
+                        ID_trapped = 1'b1;
+                    if (raw_imm == 12'b0011_0000_0010) begin
+                        ID_trap_status = `TRAP_MRET;
+                    end
+                    else if (raw_imm[0]) begin
+                        ID_trap_status = `TRAP_EBREAK;
+                    end
+                    else if (raw_imm == 12'b0) begin
+                        ID_trap_status = `TRAP_ECALL;
+                    end
+                end
+                else begin
+                    ID_trapped = 1'b0;
+                    ID_trap_status = `TRAP_NONE;
+                end
+            end
+
+            `OPCODE_BRANCH: begin // Misaligned
+            if (branch_estimation == 1'b1) begin
+                if (branch_target_lsbs == 2'b0) begin
+                    ID_trapped = 1'b0;
+                    ID_trap_status = `TRAP_NONE;
+                end 
+                else begin
+                    ID_trapped = 1'b1;
+                    ID_trap_status = `TRAP_MISALIGNED_INSTRUCTION;
+                end
+            end
+            end
+
+            default: begin
+                ID_trapped = 1'b0;
+                ID_trap_status = `TRAP_NONE;
+            end
+
         endcase
 
-		if (EX_opcode == `OPCODE_JAL || EX_opcode == `OPCODE_JALR) begin
-			if (jump_target_lsbs == 2'b0) begin
-					trapped = 0;
-					trap_status = `TRAP_NONE;
-				end
-				else begin
-					trapped = 1;
-					trap_status = `TRAP_MISALIGNED_INSTRUCTION;
-				end
-		end
-		if (misalinged_memory) begin
-			trapped = 1;
-			trap_status = `TRAP_MISALIGNED_MEMORY;
-		end
-	end
-	
+        EX_trapped = 1'b0;
+        EX_trap_status = `TRAP_NONE;
+
+        case (EX_opcode)
+            `OPCODE_STORE: begin
+                case (EX_funct3)
+                    `STORE_SH: begin
+                        if (alu_result[0] == 1'b1) begin
+                            EX_trapped = 1'b1;
+                            EX_trap_status = `TRAP_MISALIGNED_STORE;
+                        end else begin
+                            EX_trapped = 1'b0;
+                            EX_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    `STORE_SW: begin
+                        if (alu_result[1:0] != 2'b00) begin
+                            EX_trapped = 1'b1;
+                            EX_trap_status = `TRAP_MISALIGNED_STORE;
+                        end else begin
+                            EX_trapped = 1'b0;
+                            EX_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    default: begin
+                        EX_trapped = 1'b0;
+                        EX_trap_status = `TRAP_NONE;
+                    end 
+                endcase
+            end
+
+            `OPCODE_LOAD: begin
+                case (EX_funct3)
+                    `LOAD_LH, `LOAD_LHU: begin
+                        if (alu_result[0] == 1'b1) begin
+                            EX_trapped = 1'b1;
+                            EX_trap_status = `TRAP_MISALIGNED_LOAD;
+                        end else begin
+                            EX_trapped = 1'b0;
+                            EX_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    `LOAD_LW: begin
+                        if (alu_result[1:0] != 2'b00) begin
+                            EX_trapped = 1'b1;
+                            EX_trap_status = `TRAP_MISALIGNED_LOAD;
+                        end else begin
+                            EX_trapped = 1'b0;
+                            EX_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    default: begin
+                        EX_trapped = 1'b0;
+                        EX_trap_status = `TRAP_NONE;
+                    end
+                endcase
+            end
+            `OPCODE_JAL, `OPCODE_JALR: begin
+                if (alu_result == 2'b0) begin
+                    EX_trapped = 1'b0;
+                    EX_trap_status = `TRAP_NONE;
+                end else begin
+                    EX_trapped = 1'b1;
+                    EX_trap_status = `TRAP_MISALIGNED_INSTRUCTION;
+                end
+            end    
+            default: begin
+                EX_trapped = 1'b0;
+                EX_trap_status = `TRAP_NONE;
+            end
+        endcase
+
+        if (EX_trapped) begin
+            trapped = 1'b1;
+            trap_status = EX_trap_status;
+        end else if (ID_trapped) begin
+            trapped = 1'b1;
+            trap_status = ID_trap_status;
+        end else begin
+            trapped = 1'b0;
+            trap_status = `TRAP_NONE;
+        end
+    end
+        /* For Illegal Instruction Exception
+        if (csr_write_enable && csr_write && !valid_write_csr) begin
+            trapped = 1'b1;
+            trap_status = `TRAP_ILLEGAL_INSTRUCTION;
+        end
+        */
 endmodule


### PR DESCRIPTION
## Revise Exception Detector to separately handle MISALIGNED STORE and LOAD exceptions
- Exceptions are now detected independently in both the _ID_ and _EX pipeline stages_.
- The previous integrated ***MISALIGNED MEMORY*** exception has been separated into ***MISALIGNED STORE*** and ***MISALIGNED LOAD*** exceptions. 

This aligns with the **RISC-V ISA Manual**, which specifies distinct exception codes for each type within the `CSR; mcause`.
Logic's test has been verified without its individual testbench by testing it in top module in Vivado and iverilog.

**Note**: Initially, an ***ILLEGAL INSTRUCTION*** exception was intended to handle write accesses to undefined `CSR`s. 
However, due to significant increases in design complexity and verification effort, this implementation has been temporarily suspended. The related code sections have been commented out to facilitate potential future use.