### PR TITLE
[Feat] Revise Pipeline Registers by refactoring stall logic and reintroducing flush logic

### DIFF
--- a/RV32I/modules/ID_EX_Register.v
+++ b/RV32I/modules/ID_EX_Register.v
@@ -5,7 +5,7 @@ module ID_EX_Register #(
     input wire clk,
     input wire reset,
     input wire flush,
-    input wire pipeline_stall,
+    input wire ID_EX_stall,
 
     // signal from IF phase
     // input wire [XLEN-1:0] IF_PC but why? What was this for?
@@ -93,33 +93,7 @@ always @(posedge clk or posedge reset) begin
         EX_rs2 <= 5'b0;
         EX_imm <= {XLEN{1'b0}};
         EX_csr_read_data <= {XLEN{1'b0}};
-    end else if (pipeline_stall) begin
-        EX_pc <= EX_pc;
-        EX_pc_plus_4 <= EX_pc_plus_4;
-        EX_branch_estimation <= EX_branch_estimation;
-        EX_instruction <= EX_instruction;
-
-        EX_jump <= EX_jump;
-        EX_memory_read <= EX_memory_read;
-        EX_memory_write <= EX_memory_write;
-        EX_register_file_write_data_select <= EX_register_file_write_data_select;
-        EX_register_write_enable <= EX_register_write_enable;
-        EX_csr_write_enable <= EX_csr_write_enable;
-        EX_branch <= EX_branch;
-        EX_alu_src_A_select <= EX_alu_src_A_select;
-        EX_alu_src_B_select <= EX_alu_src_B_select;
-        EX_opcode <= EX_opcode;
-        EX_funct3 <= EX_funct3;
-        EX_funct7 <= EX_funct7;
-        EX_rd <= EX_rd;
-        EX_raw_imm <= EX_raw_imm;
-        EX_read_data1 <= EX_read_data1;
-        EX_read_data2 <= EX_read_data2;
-        EX_rs1 <= EX_rs1;
-        EX_rs2 <= EX_rs2;
-        EX_imm <= EX_imm;
-        EX_csr_read_data <= EX_csr_read_data;
-    end else begin
+    end else if (!ID_EX_stall) begin
         EX_pc <= ID_pc;
         EX_pc_plus_4 <= ID_pc_plus_4;
         EX_branch_estimation <= ID_branch_estimation;
@@ -145,7 +119,7 @@ always @(posedge clk or posedge reset) begin
         EX_rs2 <= ID_rs2;
         EX_imm <= ID_imm;
         EX_csr_read_data <= ID_csr_read_data;
-    end
+    end 
 end
 
 endmodule

--- a/RV32I/modules/IF_ID_Register.v
+++ b/RV32I/modules/IF_ID_Register.v
@@ -5,7 +5,7 @@ module IF_ID_Register #(
     input wire clk,
     input wire reset,
     input wire flush,
-    input wire pipeline_stall,
+    input wire IF_ID_stall,
 
     // signals from IF phase
     input wire [XLEN-1:0] IF_pc,
@@ -32,13 +32,7 @@ always @(posedge clk or posedge reset) begin
         ID_pc_plus_4 <= {XLEN{1'b0}};
         ID_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
         ID_branch_estimation <= 1'b0;
-    end else if (pipeline_stall) begin
-        ID_pc <= ID_pc;
-        ID_pc_plus_4 <= ID_pc_plus_4;
-        ID_instruction <= ID_instruction;
-        ID_branch_estimation <= ID_branch_estimation;
-    end
-    else begin
+    end else if (!IF_ID_stall) begin
         ID_pc <= IF_pc;
         ID_pc_plus_4 <= IF_pc_plus_4;
         ID_instruction <= IF_instruction;


### PR DESCRIPTION
## Revised Pipeline Registers' stall logic and reintroduced flush logic.
- Refactored Pipeline Registers' stall logic for better Synthesis result in FPGA implementation
- Reintroduced pipeline flush logic to **EX_MEM_Register** and **MEM_WB_Register** for PTH done flush.

Pipelined existing `rs1` value to forward data if the ***CSR RAW Hazard*** occurs.

**Note** : Since the **CSR File** design has been revised to _synchronous operation_, **RAW** (Read-After-Write) hazards now occur. Efforts have been made to address the ***CSR RAW hazard*** issue through techniques such as **data forwarding**. However, due to significant increases in both design complexity and verification requirements, this implementation has been temporarily suspended. The relevant code sections have been commented out for potential future use.

### Current Issue:
When consecutive **Zicsr instructions** access the _same CSR address_, the updated CSR value from the preceding instruction should be forwarded to subsequent instructions. While forwarding from MEM to EX stage for ALU calculations is already implemented, forwarding from retired instruction's value to the WB (Write-Back) stage remains problematic. 
This specific issue will be addressed in the near future.

### Important:
Please be aware that the **CSR RAW hazard issue** is currently unresolved.