### PR TITLE
[Feat] Revise Exception Detector output to Synchronous for FPGA Implementation

### DIFF
--- a/RV32I/modules/Exception_Detector.v
+++ b/RV32I/modules/Exception_Detector.v
@@ -4,13 +4,19 @@
 `include "modules/headers/trap.vh"
 
 module ExceptionDetector (
+    input clk,
+    input reset,
     input [6:0] ID_opcode,            // opcode from ID Phase
     input [6:0] EX_opcode,            // opcode from EX Phase
+    input [6:0] MEM_opcode,           // opcode from MEM Phase for Synchronous Exception Detector
     // input [4:0] rs1,                   // For Illegal Instruction Exception
     input [2:0] ID_funct3,                // funct3
     input [2:0] EX_funct3,
+    input [2:0] MEM_funct3,
     input [1:0] alu_result,         // LSBs of jump target and data_memory_address
+    input [1:0] MEM_alu_result,
     input [11:0] raw_imm,            // raw_imm field to distinguish EBREAK, ECALL and MRET, CSR_Address
+    input [11:0] EX_raw_imm,
     input csr_write_enable,         // CSR WE signal from Control Unit for Detecting Illegal CSR access from ID Phase.
     input [1:0] branch_target_lsbs,        // LSBs of branch target
     input branch_estimation,
@@ -22,7 +28,10 @@ module ExceptionDetector (
     reg [2:0] ID_trap_status;
     reg EX_trapped;
     reg [2:0] EX_trap_status;
-
+    reg MEM_trapped;
+    reg [2:0] MEM_trap_status;
+    reg trapped_combinatorial;
+    reg [2:0] trap_status_combinatorial;
 
     /* For Illegal Instruction Exception
     wire csr_write;
@@ -40,7 +49,7 @@ module ExceptionDetector (
         ID_trapped = 1'b0;
 
         case (ID_opcode)
-            `OPCODE_FENCE: begin    // Zifence
+            `OPCODE_FENCE: begin    // Zifencei
                 if (ID_funct3 == 3'b001) begin
                     ID_trapped = 1'b1;
                     ID_trap_status = `TRAP_FENCEI;
@@ -90,6 +99,25 @@ module ExceptionDetector (
         EX_trap_status = `TRAP_NONE;
 
         case (EX_opcode)
+            `OPCODE_ENVIRONMENT: begin // EBREAK, ECALL, MRET
+                if (EX_funct3 == 3'b0) begin
+                        EX_trapped = 1'b1;
+                    if (EX_raw_imm == 12'b0011_0000_0010) begin
+                        EX_trap_status = `TRAP_MRET;
+                    end
+                    else if (EX_raw_imm[0]) begin
+                        EX_trap_status = `TRAP_EBREAK;
+                    end
+                    else if (EX_raw_imm == 12'b0) begin
+                        EX_trap_status = `TRAP_ECALL;
+                    end
+                end
+                else begin
+                    EX_trapped = 1'b0;
+                    EX_trap_status = `TRAP_NONE;
+                end
+            end
+
             `OPCODE_STORE: begin
                 case (EX_funct3)
                     `STORE_SH: begin
@@ -158,15 +186,90 @@ module ExceptionDetector (
             end
         endcase
 
-        if (EX_trapped) begin
-            trapped = 1'b1;
-            trap_status = EX_trap_status;
+        MEM_trapped = 1'b0;
+        MEM_trap_status = `TRAP_NONE;
+
+        case (MEM_opcode)
+            `OPCODE_STORE: begin
+                case (MEM_funct3)
+                    `STORE_SH: begin
+                        if (MEM_alu_result[0] == 1'b1) begin
+                            MEM_trapped = 1'b1;
+                            MEM_trap_status = `TRAP_MISALIGNED_STORE;
+                        end else begin
+                            MEM_trapped = 1'b0;
+                            MEM_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    `STORE_SW: begin
+                        if (MEM_alu_result[1:0] != 2'b00) begin
+                            MEM_trapped = 1'b1;
+                            MEM_trap_status = `TRAP_MISALIGNED_STORE;
+                        end else begin
+                            MEM_trapped = 1'b0;
+                            MEM_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    default: begin
+                        MEM_trapped = 1'b0;
+                        MEM_trap_status = `TRAP_NONE;
+                    end 
+                endcase
+            end
+
+            `OPCODE_LOAD: begin
+                case (MEM_funct3)
+                    `LOAD_LH, `LOAD_LHU: begin
+                        if (MEM_alu_result[0] == 1'b1) begin
+                            MEM_trapped = 1'b1;
+                            MEM_trap_status = `TRAP_MISALIGNED_LOAD;
+                        end else begin
+                            MEM_trapped = 1'b0;
+                            MEM_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    `LOAD_LW: begin
+                        if (MEM_alu_result[1:0] != 2'b00) begin
+                            MEM_trapped = 1'b1;
+                            MEM_trap_status = `TRAP_MISALIGNED_LOAD;
+                        end else begin
+                            MEM_trapped = 1'b0;
+                            MEM_trap_status = `TRAP_NONE;
+                        end
+                    end
+                    default: begin
+                        MEM_trapped = 1'b0;
+                        MEM_trap_status = `TRAP_NONE;
+                    end
+                endcase
+            end
+            `OPCODE_JAL, `OPCODE_JALR: begin
+                if (MEM_alu_result == 2'b0) begin
+                    MEM_trapped = 1'b0;
+                    MEM_trap_status = `TRAP_NONE;
+                end else begin
+                    MEM_trapped = 1'b1;
+                    MEM_trap_status = `TRAP_MISALIGNED_INSTRUCTION;
+                end
+            end    
+            default: begin
+                MEM_trapped = 1'b0;
+                MEM_trap_status = `TRAP_NONE;
+            end
+        endcase
+
+        if (MEM_trapped) begin
+            trapped_combinatorial = 1'b1;
+            trap_status_combinatorial = MEM_trap_status;
+        end else if (EX_trapped) begin
+            trapped_combinatorial = 1'b1;
+            trap_status_combinatorial = EX_trap_status;
         end else if (ID_trapped) begin
-            trapped = 1'b1;
-            trap_status = ID_trap_status;
+            trapped_combinatorial = 1'b1;
+            trap_status_combinatorial = ID_trap_status;
         end else begin
-            trapped = 1'b0;
-            trap_status = `TRAP_NONE;
+            trapped_combinatorial = 1'b0;
+            trap_status_combinatorial = `TRAP_NONE;
         end
     end
         /* For Illegal Instruction Exception
@@ -175,4 +278,15 @@ module ExceptionDetector (
             trap_status = `TRAP_ILLEGAL_INSTRUCTION;
         end
         */
+
+    // Synchronous trap signal output
+    always @(posedge clk  or posedge reset) begin
+        if (reset) begin
+            trapped <= 1'b0;
+            trap_status <= `TRAP_NONE;
+        end else begin
+            trapped <= trapped_combinatorial;
+            trap_status <= trap_status_combinatorial;
+        end
+    end
 endmodule


### PR DESCRIPTION
## Synchronous Exception Detector

**RV32I46F_5SP**를 FPGA에 구현하기 위해서 Vivado를 통해 시뮬레이션을 돌려봤습니다.
그 중 Post Synthesis Timing Simulation(PSTS)에서 exception 발생 이후 trap_handling(PTH 포함)로 넘어가는데에서 파형이 UNKNOWN으로 바뀌는 것을 확인했고, 이를 해결하기 위해 **Exception Detector** 모듈의 출력 신호를 동기식으로 수정하기로 했습니다.
![Unstable_Trap_Status](https://github.com/user-attachments/assets/049db600-42c5-4ace-9720-4c63b4497860)

파형을 자세히 보면, 0x0000_1000 Trap Handler 주소로 분기하기 이전에 `trap_status` 신호가 본래 한가지로 특정되어 진행되어야하는 로직에서 한 클럭 사이클 이내에 여러가지 코드로 변화하는 것을 확인하였고, 이와 같은 불안정성이 직접적인 원인이 될 수 있다고 판단해 clk의 rising edge에서만 값을 출력해 이후 다음 클럭 사이클까지 값의 변화가 최대한 없도록 보장하여 불안정성을 없애고자 하였습니다.

수정된 로직은 개별 테스트벤치 없이 Vivado와 iverilog에서 탑 모듈 시뮬레이션을 통해 검증되었습니다.
![Stabilized_Trap_Status](https://github.com/user-attachments/assets/88a6e3a2-eb36-4e41-b280-5219fc3f1cd8)

To implement the **RV32I46F_5SP** architecture on FPGA, a simulation was conducted using Vivado. 
During the _Post Synthesis Timing Simulation_ (PSTS), an issue was identified where signals transitioned to an UNKNOWN state during the transition from exception occurrence to trap handling (including pre-trap handling, PTH). 
To address this, the output signals of the Exception Detector module were modified to use synchronous logic.
![Unstable_Trap_Status](https://github.com/user-attachments/assets/049db600-42c5-4ace-9720-4c63b4497860)

Detailed waveform analysis revealed that the `trap_status` signal, which should remain stable throughout a given logic cycle, was instead fluctuating through multiple states within a single clock cycle prior to branching to the trap handler address (0x00001000). This instability was identified as a potential root cause of the issue. 
Therefore, the solution involves ensuring that signals are output strictly on the rising edge of the clock, thus guaranteeing stability until the subsequent clock cycle and eliminating signal instability.
![Stabilized_Trap_Status](https://github.com/user-attachments/assets/88a6e3a2-eb36-4e41-b280-5219fc3f1cd8)
Logic's test has been verified without its individual testbench by testing it in top module in Vivado and iverilog.