### PR TITLE
[Feat] Revise Hazard Unit for Synchronous Exception Detector

### DIFF
--- a/RV32I/modules/Hazard_Unit.v
+++ b/RV32I/modules/Hazard_Unit.v
@@ -123,6 +123,7 @@ module HazardUnit (
             IF_ID_flush = 1'b1;
             ID_EX_flush = 1'b1;
             EX_MEM_flush = 1'b1;
+            MEM_WB_flush = 1'b1;
         end
 
         if (standby_mode) begin // For ID Phase Excpetion handling


### PR DESCRIPTION
## Revise Hazard Unit for Synchronous Exception Detector

- Now `pth_done_flush` logic includes **MEM_WB_Register** flush
(since **Exception Detector** module has been revised to ***Synchronous***, `pth_done_flush` execution also has to be targeted 1 Clock Cycle delayed time.)

Logic's test has been verified without its individual testbench by testing it in top module in Vivado and iverilog.
