### PR TITLE
[Feat] Implement Register File Debug module for 46F5SP_SoC_TOP FPGA verification and debugging

### DIFF
--- a/RV32I/modules/Register_File_Debug.v
+++ b/RV32I/modules/Register_File_Debug.v
@@ -1,0 +1,64 @@
+module RegisterFileDebug (
+    input clk,                      // clock signal
+    input clk_enable,
+    input [4:0] read_reg1,          // take address of register 1 to read stored value
+    input [4:0] read_reg2,          // take address of register 2 to read stored value
+    input [4:0] write_reg,          // take address of register to write value
+    input [31:0] write_data,        // data to write
+    input write_enable,             // enabling signal for writing register
+	
+    output reg [31:0] read_data1,   // data from register 1
+    output reg [31:0] read_data2,    // data from register 2
+
+    // Debug outputs: last-written register and its data from WB Phase
+    output [4:0] debug_reg_addr,
+    output [31:0] debug_reg_data
+);
+
+    reg [31:0] registers [0:31]; // 32 registers with 32 bits each
+    
+    integer i;
+    initial begin
+    for (i = 1; i < 32; i = i + 1) registers[i] = 32'b0;
+    end
+
+    // Read operation
+    always @(*) begin
+        if (read_reg1 == 5'd0) begin
+            read_data1 = 32'd0;
+        end else if (clk_enable && write_enable && (write_reg == read_reg1)) begin
+            read_data1 = write_data;
+        end else begin
+            read_data1 = registers[read_reg1];
+        end
+
+        if (read_reg2 == 5'd0) begin
+            read_data2 = 32'd0;
+        end else if (clk_enable && write_enable && (write_reg == read_reg2)) begin
+            read_data2 = write_data;
+        end else begin
+            read_data2 = registers[read_reg2];
+        end
+    end
+
+    // Write operation
+    always @(posedge clk) begin
+        if (clk_enable && write_enable && write_reg != 5'd0) begin
+            registers[write_reg] <= write_data; // write to register if not x0
+        end
+    end
+
+    // Debug output operation
+    reg [4:0]  debug_reg_addr_q;
+    reg [31:0] debug_reg_data_q;
+
+    always @(posedge clk) begin
+        if (clk_enable && write_enable && write_reg != 5'd0) begin
+            debug_reg_addr_q <= write_reg;
+            debug_reg_data_q <= write_data;
+        end
+    end
+    assign debug_reg_addr = debug_reg_addr_q;
+    assign debug_reg_data = debug_reg_data_q;
+
+endmodule


### PR DESCRIPTION
## 레지스터 파일 디버그 모듈
**46F5SP_SoC_TOP** 모듈의 FPGA 구현과 실시간 검증, 디버깅을 위해서 **Register File Debug** 모듈이 추가되었습니다.
이 디버그 모듈은 기존 **Register File** 모듈에서 디버그용 출력 신호 2개와 그 로직을 추가한 것입니다.
- `write_reg` (목적지 레지스터 주소; rd)
- `write_data` (해당 레지스터에 쓰여질 데이터 값)

이를 통해 ***RV32I46F_5SP*** 프로세서의 WriteBack 파이프라인 단계를 FPGA 검증 과정에서 확인할 수 있습니다. 

Vivado에서 Synthesis, Implementation, 실제 FPGA bitstream generate 및 download 후 SoC 구동을 통해 모듈의 개별적인 testbench 없이 검증되었습니다.

## Register File Debug Module
**Register File Debug** module has been added for the **46F5SP_SoC_TOP** FPGA implementation to support runtime verification and debugging. 

This standalone debug module extends the original **Register File** by exposing two additional outputs
- `write_reg` (the destination register address)
- `write_data` (the data value written)

which reflect the WriteBack stage of the ***RV32I46F_5SP*** pipeline. 
These signals allow real-time observation of register updates during FPGA verification without impacting the core Register File logic.

Logic's test has been verified without its individual testbench by performing Synthesis, Implementation, bitstream generation, and FPGA download, subsequently running and testing it within the top-level SoC module in Vivado.