### PR TITLE
[Feat] Revise Pipeline Registers separating reset flush logic and adding clock enable signal

### DIFF
--- a/RV32I/modules/EX_MEM_Register.v
+++ b/RV32I/modules/EX_MEM_Register.v
@@ -3,6 +3,7 @@ module EX_MEM_Register #(
 )(
     // pipeline register control signals
     input wire clk,
+    input wire clk_enable,
     input wire reset,
     input wire flush,
     input wire EX_MEM_stall,
@@ -52,7 +53,7 @@ module EX_MEM_Register #(
 );
 
 always @(posedge clk or posedge reset) begin
-    if (reset || flush) begin
+    if (reset) begin
         MEM_pc <= {XLEN{1'b0}};
         MEM_pc_plus_4 <= {XLEN{1'b0}};
         MEM_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
@@ -72,27 +73,49 @@ always @(posedge clk or posedge reset) begin
         MEM_csr_read_data <= {XLEN{1'b0}};
 
         MEM_alu_result <= {XLEN{1'b0}};
-    end else if (!EX_MEM_stall) begin
-        MEM_pc <= EX_pc;
-        MEM_pc_plus_4 <= EX_pc_plus_4;
-        MEM_instruction <= EX_instruction;
+    end else if (clk_enable) begin
+        if (flush) begin
+            MEM_pc <= {XLEN{1'b0}};
+            MEM_pc_plus_4 <= {XLEN{1'b0}};
+            MEM_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
 
-        MEM_memory_read <= EX_memory_read;
-        MEM_memory_write <= EX_memory_write;
-        MEM_register_file_write_data_select <= EX_register_file_write_data_select;
-        MEM_register_write_enable <= EX_register_write_enable;
-        MEM_csr_write_enable <= EX_csr_write_enable;
-        MEM_opcode <= EX_opcode;
-        MEM_funct3 <= EX_funct3;
-        MEM_rs1 <= EX_rs1;
-        MEM_rd <= EX_rd;
-        MEM_read_data2 <= EX_read_data2;
-        MEM_imm <= EX_imm;
-        MEM_raw_imm <= EX_raw_imm;
-        MEM_csr_read_data <= EX_csr_read_data;
+            MEM_memory_read <= 1'b0;
+            MEM_memory_write <= 1'b0;
+            MEM_register_file_write_data_select <= 3'b0;
+            MEM_register_write_enable <= 1'b0;
+            MEM_csr_write_enable <= 1'b0;
+            MEM_opcode <= 7'b0;
+            MEM_funct3 <= 3'b0;
+            MEM_rs1 <= 5'b0;
+            MEM_rd <= 5'b0;
+            MEM_read_data2 <= {XLEN{1'b0}};
+            MEM_imm <= {XLEN{1'b0}};
+            MEM_raw_imm <= 20'b0;
+            MEM_csr_read_data <= {XLEN{1'b0}};
 
-        MEM_alu_result <= EX_alu_result;
-    end 
+            MEM_alu_result <= {XLEN{1'b0}};
+        end else if (!EX_MEM_stall) begin
+            MEM_pc <= EX_pc;
+            MEM_pc_plus_4 <= EX_pc_plus_4;
+            MEM_instruction <= EX_instruction;
+
+            MEM_memory_read <= EX_memory_read;
+            MEM_memory_write <= EX_memory_write;
+            MEM_register_file_write_data_select <= EX_register_file_write_data_select;
+            MEM_register_write_enable <= EX_register_write_enable;
+            MEM_csr_write_enable <= EX_csr_write_enable;
+            MEM_opcode <= EX_opcode;
+            MEM_funct3 <= EX_funct3;
+            MEM_rs1 <= EX_rs1;
+            MEM_rd <= EX_rd;
+            MEM_read_data2 <= EX_read_data2;
+            MEM_imm <= EX_imm;
+            MEM_raw_imm <= EX_raw_imm;
+            MEM_csr_read_data <= EX_csr_read_data;
+
+            MEM_alu_result <= EX_alu_result;
+        end 
+    end
     
 end
 

--- a/RV32I/modules/ID_EX_Register.v
+++ b/RV32I/modules/ID_EX_Register.v
@@ -3,6 +3,7 @@ module ID_EX_Register #(
 )(
     // pipeline register control signals
     input wire clk,
+    input clk_enable,
     input wire reset,
     input wire flush,
     input wire ID_EX_stall,
@@ -67,7 +68,7 @@ module ID_EX_Register #(
 );
 
 always @(posedge clk or posedge reset) begin
-    if (reset || flush) begin
+    if (reset) begin
         EX_pc <= {XLEN{1'b0}};
         EX_pc_plus_4 <= {XLEN{1'b0}};
         EX_branch_estimation <= 1'b0;
@@ -93,32 +94,60 @@ always @(posedge clk or posedge reset) begin
         EX_rs2 <= 5'b0;
         EX_imm <= {XLEN{1'b0}};
         EX_csr_read_data <= {XLEN{1'b0}};
-    end else if (!ID_EX_stall) begin
-        EX_pc <= ID_pc;
-        EX_pc_plus_4 <= ID_pc_plus_4;
-        EX_branch_estimation <= ID_branch_estimation;
-        EX_instruction <= ID_instruction;
+    end else if (clk_enable) begin
+        if (flush) begin
+            EX_pc <= {XLEN{1'b0}};
+            EX_pc_plus_4 <= {XLEN{1'b0}};
+            EX_branch_estimation <= 1'b0;
+            EX_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
 
-        EX_jump <= ID_jump;
-        EX_memory_read <= ID_memory_read;
-        EX_memory_write <= ID_memory_write;
-        EX_register_file_write_data_select <= ID_register_file_write_data_select;
-        EX_register_write_enable <= ID_register_write_enable;
-        EX_csr_write_enable <= ID_csr_write_enable;
-        EX_branch <= ID_branch;
-        EX_alu_src_A_select <= ID_alu_src_A_select;
-        EX_alu_src_B_select <= ID_alu_src_B_select;
-        EX_opcode <= ID_opcode;
-        EX_funct3 <= ID_funct3;
-        EX_funct7 <= ID_funct7;
-        EX_rd <= ID_rd;
-        EX_raw_imm <= ID_raw_imm;
-        EX_read_data1 <= ID_read_data1;
-        EX_read_data2 <= ID_read_data2;
-        EX_rs1 <= ID_rs1;
-        EX_rs2 <= ID_rs2;
-        EX_imm <= ID_imm;
-        EX_csr_read_data <= ID_csr_read_data;
+            EX_jump <= 1'b0;
+            EX_memory_read <= 1'b0;
+            EX_memory_write <= 1'b0;
+            EX_register_file_write_data_select <= 3'b0;
+            EX_register_write_enable <= 1'b0;
+            EX_csr_write_enable <= 1'b0;
+            EX_branch <= 1'b0;
+            EX_alu_src_A_select <= 2'b0;
+            EX_alu_src_B_select <= 3'b0;
+            EX_opcode <= 7'b0;
+            EX_funct3 <= 3'b0;
+            EX_funct7 <= 7'b0;
+            EX_rd <= 5'b0;
+            EX_raw_imm <= 20'b0;
+            EX_read_data1 <= {XLEN{1'b0}};
+            EX_read_data2 <= {XLEN{1'b0}};
+            EX_rs1 <= 5'b0;
+            EX_rs2 <= 5'b0;
+            EX_imm <= {XLEN{1'b0}};
+            EX_csr_read_data <= {XLEN{1'b0}};
+        end else if (!ID_EX_stall) begin
+            EX_pc <= ID_pc;
+            EX_pc_plus_4 <= ID_pc_plus_4;
+            EX_branch_estimation <= ID_branch_estimation;
+            EX_instruction <= ID_instruction;
+
+            EX_jump <= ID_jump;
+            EX_memory_read <= ID_memory_read;
+            EX_memory_write <= ID_memory_write;
+            EX_register_file_write_data_select <= ID_register_file_write_data_select;
+            EX_register_write_enable <= ID_register_write_enable;
+            EX_csr_write_enable <= ID_csr_write_enable;
+            EX_branch <= ID_branch;
+            EX_alu_src_A_select <= ID_alu_src_A_select;
+            EX_alu_src_B_select <= ID_alu_src_B_select;
+            EX_opcode <= ID_opcode;
+            EX_funct3 <= ID_funct3;
+            EX_funct7 <= ID_funct7;
+            EX_rd <= ID_rd;
+            EX_raw_imm <= ID_raw_imm;
+            EX_read_data1 <= ID_read_data1;
+            EX_read_data2 <= ID_read_data2;
+            EX_rs1 <= ID_rs1;
+            EX_rs2 <= ID_rs2;
+            EX_imm <= ID_imm;
+            EX_csr_read_data <= ID_csr_read_data;
+        end 
     end 
 end
 

--- a/RV32I/modules/IF_ID_Register.v
+++ b/RV32I/modules/IF_ID_Register.v
@@ -3,6 +3,7 @@ module IF_ID_Register #(
 )(
     // pipeline register control signals
     input wire clk,
+    input wire clk_enable,
     input wire reset,
     input wire flush,
     input wire IF_ID_stall,
@@ -24,19 +25,21 @@ always @(posedge clk or posedge reset) begin
     if (reset) begin
         ID_pc <= {XLEN{1'b0}};
         ID_pc_plus_4 <= {XLEN{1'b0}};
-        ID_instruction <= 32'b0;
+        ID_instruction <= 32'h0000_0013;
         ID_branch_estimation <= 1'b0;
     end 
-    else if (flush) begin   
-        ID_pc <= {XLEN{1'b0}};
-        ID_pc_plus_4 <= {XLEN{1'b0}};
-        ID_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
-        ID_branch_estimation <= 1'b0;
-    end else if (!IF_ID_stall) begin
-        ID_pc <= IF_pc;
-        ID_pc_plus_4 <= IF_pc_plus_4;
-        ID_instruction <= IF_instruction;
-        ID_branch_estimation <= IF_branch_estimation;
+    else if (clk_enable) begin
+        if (flush) begin   
+            ID_pc <= {XLEN{1'b0}};
+            ID_pc_plus_4 <= {XLEN{1'b0}};
+            ID_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
+            ID_branch_estimation <= 1'b0;
+        end else if (!IF_ID_stall) begin
+            ID_pc <= IF_pc;
+            ID_pc_plus_4 <= IF_pc_plus_4;
+            ID_instruction <= IF_instruction;
+            ID_branch_estimation <= IF_branch_estimation;
+        end
     end
 end
 

--- a/RV32I/modules/MEM_WB_Register.v
+++ b/RV32I/modules/MEM_WB_Register.v
@@ -3,6 +3,7 @@ module MEM_WB_Register #(
 )(
     // pipeline register control signals
     input wire clk,
+    input wire clk_enable,
     input wire reset,
     input wire MEM_WB_stall,
     input wire flush,
@@ -46,7 +47,7 @@ module MEM_WB_Register #(
 );
 
 always @(posedge clk or posedge reset) begin
-    if (reset || flush) begin
+    if (reset) begin
         WB_pc <= {XLEN{1'b0}};
         WB_pc_plus_4 <= {XLEN{1'b0}};
         WB_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
@@ -63,23 +64,42 @@ always @(posedge clk or posedge reset) begin
         WB_opcode <= 7'b0;
         
         WB_byte_enable_logic_register_file_write_data <= {XLEN{1'b0}};
-    end else if (!MEM_WB_stall) begin
-        WB_pc <= MEM_pc;
-        WB_pc_plus_4 <= MEM_pc_plus_4;
-        WB_instruction <= MEM_instruction;
+    end else if (clk_enable) begin
+        if (flush) begin
+            WB_pc <= {XLEN{1'b0}};
+            WB_pc_plus_4 <= {XLEN{1'b0}};
+            WB_instruction <= 32'h0000_0013; // ADDI x0, x0, 0 = RISC-V NOP, HINT
 
-        WB_register_file_write_data_select <= MEM_register_file_write_data_select;
-        WB_imm <= MEM_imm;
-        WB_raw_imm <= MEM_raw_imm;
-        WB_csr_read_data <= MEM_csr_read_data;
-        WB_alu_result <= MEM_alu_result;
-        WB_register_write_enable <= MEM_register_write_enable;
-        WB_csr_write_enable <= MEM_csr_write_enable;
-        WB_rs1 <= MEM_rs1;
-        WB_rd <= MEM_rd;
-        WB_opcode <= MEM_opcode;
-        
-        WB_byte_enable_logic_register_file_write_data <= MEM_byte_enable_logic_register_file_write_data;
+            WB_register_file_write_data_select <= 3'b0;
+            WB_imm <= {XLEN{1'b0}};
+            WB_raw_imm <= 20'b0;
+            WB_csr_read_data <= {XLEN{1'b0}};
+            WB_alu_result <= {XLEN{1'b0}};
+            WB_register_write_enable <= 1'b0;
+            WB_csr_write_enable <= 1'b0;
+            WB_rs1 <= 5'b0;
+            WB_rd <= 5'b0;
+            WB_opcode <= 7'b0;
+            
+            WB_byte_enable_logic_register_file_write_data <= {XLEN{1'b0}};
+        end else if (!MEM_WB_stall) begin
+            WB_pc <= MEM_pc;
+            WB_pc_plus_4 <= MEM_pc_plus_4;
+            WB_instruction <= MEM_instruction;
+
+            WB_register_file_write_data_select <= MEM_register_file_write_data_select;
+            WB_imm <= MEM_imm;
+            WB_raw_imm <= MEM_raw_imm;
+            WB_csr_read_data <= MEM_csr_read_data;
+            WB_alu_result <= MEM_alu_result;
+            WB_register_write_enable <= MEM_register_write_enable;
+            WB_csr_write_enable <= MEM_csr_write_enable;
+            WB_rs1 <= MEM_rs1;
+            WB_rd <= MEM_rd;
+            WB_opcode <= MEM_opcode;
+            
+            WB_byte_enable_logic_register_file_write_data <= MEM_byte_enable_logic_register_file_write_data;
+        end 
     end 
 end
 


### PR DESCRIPTION
## 파이프라인 레지스터

### 클럭 활성화 신호 추가
**46F5SP_SoC_TOP** 모듈에서는, 순차실행 모드가 있습니다. 
외부 버튼 입력을 통해 한 클럭 씩 작동하여 해당 시점의 값을 확인할 수 있도록 하는 인터페이스입니다.

이를 위해 각종 모듈에 클럭 활성화 신호 `clk_enable`를 input 으로 추가하였고, 
해당 신호의 통제에 따라 로직을 작동할 수 있도록 변경사항을 적용했습니다.

### reset 과 flush 로직 이원화 처리
기존 파이프라인 레지스터에서는 `flush`와 `reset`을 OR 처리하여 수행하였습니다. 예) *(if reset || flush)*
하지만 클럭 활성화 신호 `clk_enable` 이 추가되며 flush 자체는 시스템 구동 중에만 처리 가능해야 하기에, 
`reset`은 `clk_enable`의 값과 무관하게 로직을 처리하도록 하였고, `flush`는 `clk_enable`일 때만 처리할 수 있도록 이원화 하였습니다.

Vivado에서 Synthesis, Implementation, 실제 FPGA bitstream generate 및 download 후 SoC 구동을 통해 모듈의 개별적인 testbench 없이 검증되었습니다.

## Revise Pipeline Registers
### Clock Enable signal addition
The **46F5SP_SoC_TOP** module supports a sequential execution mode, enabling step-by-step clock operation triggered by external button inputs to observe signal values at specific clock cycles.

To implement this functionality, a clock enable signal `clk_enable` has been introduced as an input to various modules. 
Logic within these modules has been modified to operate conditionally based on the state of this control signal.

### Decoupling Reset and Flush Logic
Previously, **Pipeline Registers** treated `reset` and `flush` as a single condition (e.g., *if (reset || flush)*). 
With the introduction of `clk_enable`, however, flush must only occur during normal operation (when the clock is enabled), 
whereas reset must always be honored regardless of `clk_enable`. 

Accordingly, we have split the logic:
- `Reset` is applied unconditionally whenever asserted.
- `Flush` is only applied when both `flush` and `clk_enable` are asserted.

Logic's test has been verified without its individual testbench by performing Synthesis, Implementation, bitstream generation, and FPGA download, subsequently running and testing it within the top-level SoC module in Vivado.