### PR TITLE
[Feat] Revise Data Memory adding clock enable signal for 46F5SP_SoC_TOP FPGA verification and debugging

### DIFF
--- a/RV32I/modules/Data_Memory.v
+++ b/RV32I/modules/Data_Memory.v
@@ -1,5 +1,6 @@
 module DataMemory (
     input clk,                      // clock signal
+    input clk_enable,
     input write_enable,             // enabling signal for writing Data Memory
     input [9:0] address,            // Take address of memory to read/write value
     input [31:0] write_data,        // data to write to Data Memory
@@ -25,7 +26,7 @@ module DataMemory (
     end
 
     always @(posedge clk) begin
-        if (write_enable) begin
+        if (clk_enable && write_enable) begin
             memory[address] <= ((memory[address] & ~extended_mask) | (write_data & extended_mask));
         end
     end


### PR DESCRIPTION
## 데이터 메모리; 클럭 활성화 신호 추가
**46F5SP_SoC_TOP** 모듈에서는, 순차실행 모드가 있습니다. 
외부 버튼 입력을 통해 한 클럭 씩 작동하여 해당 시점의 값을 확인할 수 있도록 하는 인터페이스입니다.

이를 위해 각종 모듈에 클럭 활성화 신호 `clk_enable`를 input 으로 추가하였고, 해당 신호의 통제에 따라 로직을 작동할 수 있도록 변경사항을 적용했습니다.
- 이제 `clk_enable` 일 때만 쓰기가 수행됩니다.

Vivado에서 Synthesis, Implementation, 실제 FPGA bitstream generate 및 download 후 SoC 구동을 통해 모듈의 개별적인 testbench 없이 검증되었습니다.

## Revise Data Memory; add clock enable signal
The **46F5SP_SoC_TOP** module supports a sequential execution mode, enabling step-by-step clock operation triggered by external button inputs to observe signal values at specific clock cycles.

To implement this functionality, a clock enable signal (`clk_enable`) has been introduced as an input to various modules. 
Logic within these modules has been modified to operate conditionally based on the state of this control signal.
- Write is now performed only when `clk_enable` is asserted.

Logic's test has been verified without its individual testbench by performing Synthesis, Implementation, bitstream generation, and FPGA download, subsequently running and testing it within the top-level SoC module in Vivado.