### PR TITLE
[Feat] Implement Button Controller for 46F5SP_SoC_TOP FPGA verification and debugging

### DIFF
--- a/RV32I/modules/Button_Controller.v
+++ b/RV32I/modules/Button_Controller.v
@@ -1,0 +1,169 @@
+module ButtonController (
+    input clk,                      // 50MHz system clock
+    input reset,
+    
+    // Physical Button inputs (active high)
+    input btn_center,               // Center - Step by Step Execution Mode
+    input btn_up,                   // Up - Continuous / Pause toggle
+    input btn_down,                 // Down - UART Trigger for current pc and instruction output
+    input btn_left,                 // Left - UART Trigger for write register address and value output from WB Phase
+    input btn_right,                // Right - UART Trigger for alu result output from EX Phase
+    
+    // Output control signals
+    output step_pulse,              // One clock cycle pulse for single step execution
+    output continuous_mode,         // Continuous execution mode flag
+    output alu_trigger, 
+    output pc_inst_trigger,
+    output reg_trigger
+);
+
+    // Debouncing parameter for FPGA
+    localparam DEBOUNCE_CYCLES = 20'd500000; // 10ms @ 50MHz
+    
+    // Debouncing counter for each buttons
+    reg [19:0] debounce_counter [0:4];
+    reg [4:0] button_sync [0:2];        // 3 level synchronization
+    reg [4:0] button_stable;            // Stable button state
+    reg [4:0] button_prev;              // Previous button state
+    reg [4:0] button_rising_edge;       // Rising edge detection
+    
+    // Output registers
+    reg step_pulse_reg;
+    reg continuous_mode_reg;
+    reg reg_trigger_reg;
+    reg pc_inst_trigger_reg;
+    reg alu_trigger_reg;
+    
+    // Clock divider for continuous execution mode for FPGA
+    reg [25:0] continuous_counter;      // approx. cycle/0.67s @ 50MHz
+    reg continuous_pulse;
+    
+    integer i;
+    
+    // Button input array
+    wire [4:0] button_inputs = {btn_right, btn_left, btn_down, btn_up, btn_center};
+    
+    // 3 level synchronization for metastability
+    always @(posedge clk or posedge reset) begin
+        if (reset) begin
+            button_sync[0] <= 5'b0;
+            button_sync[1] <= 5'b0;
+            button_sync[2] <= 5'b0;
+        end else begin
+            button_sync[0] <= button_inputs;
+            button_sync[1] <= button_sync[0];
+            button_sync[2] <= button_sync[1];
+        end
+    end
+    
+    // Debouncing logic for each buttons
+    always @(posedge clk or posedge reset) begin
+        if (reset) begin
+            for (i = 0; i < 5; i = i + 1) begin
+                debounce_counter[i] <= 0;
+            end
+            button_stable <= 5'b0;
+        end else begin
+            for (i = 0; i < 5; i = i + 1) begin
+                if (button_sync[2][i] != button_stable[i]) begin
+                    // When button state has been changed
+                    if (debounce_counter[i] < DEBOUNCE_CYCLES) begin
+                        debounce_counter[i] <= debounce_counter[i] + 1;
+                    end else begin
+                        button_stable[i] <= button_sync[2][i];
+                        debounce_counter[i] <= 0;
+                    end
+                end else begin
+                    // When button state is stable
+                    debounce_counter[i] <= 0;
+                end
+            end
+        end
+    end
+
+    always @(posedge clk or posedge reset) begin
+        if (reset) begin
+            button_prev <= 5'b0;
+            button_rising_edge <= 5'b0;
+        end else begin
+            button_prev <= button_stable;
+            button_rising_edge <= button_stable & ~button_prev;
+        end
+    end
+    
+    // Clock generation for continuous execution mode
+    always @(posedge clk or posedge reset) begin
+        if (reset) begin
+            continuous_counter <= 0;
+            continuous_pulse <= 1'b0;
+        end else begin
+            if (continuous_counter >= 26'd33500000) begin // Approx. 0.67sec @ 50MHz
+                continuous_counter <= 0;
+                continuous_pulse <= 1'b1;
+            end else begin
+                continuous_counter <= continuous_counter + 1;
+                continuous_pulse <= 1'b0;
+            end
+        end
+    end
+    
+    // Main control Logic
+    always @(posedge clk or posedge reset) begin
+        if (reset) begin
+            step_pulse_reg <= 1'b0;
+            continuous_mode_reg <= 1'b0;
+            pc_inst_trigger_reg <= 1'b0;
+            reg_trigger_reg <= 1'b0;
+            alu_trigger_reg <= 1'b0;
+        end else begin
+            // 1 Cycle for pulse signals
+            step_pulse_reg <= 1'b0;
+            
+            // Center button
+            if (button_rising_edge[0]) begin
+                if (!continuous_mode_reg) begin
+                    step_pulse_reg <= 1'b1;
+                end
+            end
+            
+            // Up button
+            if (button_rising_edge[1]) begin
+                continuous_mode_reg <= ~continuous_mode_reg;
+            end
+            
+            // Down button - UART Trigger
+            if (button_rising_edge[2]) begin
+                pc_inst_trigger_reg <= 1'b1;
+            end else begin
+                pc_inst_trigger_reg <= 1'b0;
+            end
+            
+            // Left Button
+            if (button_rising_edge[3]) begin
+                reg_trigger_reg <= 1'b1;
+            end else begin
+                reg_trigger_reg <= 1'b0;
+            end
+            
+            // Right Button
+            if (button_rising_edge[4]) begin
+                alu_trigger_reg <= 1'b1;
+            end else begin
+                alu_trigger_reg <= 1'b0;
+            end
+            
+            // Auto stepping in continuous execution mode
+            if (continuous_mode_reg && continuous_pulse) begin
+                step_pulse_reg <= 1'b1;
+            end
+        end
+    end
+    
+    // output assign
+    assign step_pulse = step_pulse_reg;
+    assign continuous_mode = continuous_mode_reg;
+    assign pc_inst_trigger = pc_inst_trigger_reg;
+    assign reg_trigger = reg_trigger_reg;
+    assign alu_trigger = alu_trigger_reg;
+
+endmodule


### PR DESCRIPTION
## 버튼 컨트롤러 구현
**46F5SP_SoC_TOP** 모듈의 FPGA 구현과 실시간 검증, 디버깅을 위해서 **Button Controller** 모듈이 추가되었습니다.
이 모듈은 46F5SP_SoC_TOP 모듈이 FPGA에 다운로드 된 후, FPGA 보드의 버튼 입력을 제어하기 위해 설계된 모듈입니다.
아래와 같은 기능을 합니다.
- 버튼 디바운싱 처리
- 버튼 입력의 상승 엣지에서만 동작 수행하도록 엣지 검출 방식 사용
- 각 버튼에 할당된 동작 수행

Digilent 社의 Nexys Video FPGA 보드에 탑재된 총 5개의 버튼을 모두 사용하며, 각 버튼 별 할당된 역할은 다음과 같습니다.
- **위 버튼** 연속 실행 모드 / 순차 실행 모드 토글 스위치
- **중앙 버튼** 순차 실행 시 다음 클럭 사이클로 이동
- **아래 버튼** 현재 `PC 값`과 `명령어 값`을 UART로 출력하기 위한 *UART trigger* 출력
- **왼쪽 버튼** 쓰여지는 `레지스터의 주소 값`과 `데이터 값`을 UART로 출력하기 위한 *UART trigger* 출력
- **오른쪽 버튼** `ALU의 결과 값`을 UART로 출력하기 위한 *UART trigger* 출력

출력된 *UART trigger*는 **UART Debug Controller**에 입력되어 UART 인터페이스를 통해 값이 출력되도록 합니다. 
이를 통해 ***RV32I46F_5SP*** 프로세서의 동작을 FPGA 검증 과정에서 확인할 수 있습니다. 

Vivado에서 Synthesis, Implementation, 실제 FPGA bitstream generate 및 download 후 SoC 구동을 통해 모듈의 개별적인 testbench 없이 검증되었습니다.

## Button Controller

**Button Controller** module has been added to the **46F5SP_SoC_TOP** for FPGA implementation, runtime verification, and debugging. This module is specifically designed to handle button inputs from the FPGA board once the **46F5SP_SoC_TOP** module has been downloaded onto the FPGA. Its functionalities include:

- **Button debouncing**
- **Edge detection** logic to trigger actions only on the rising edge of button presses
- **Executing actions** assigned to each individual button

This implementation utilizes all five buttons available on the **Digilent Nexys Video FPGA board**, with each button assigned the following functions:

- **UP Button:** Toggles between continuous execution mode and step-by-step (sequential) execution mode  
- **CENTER Button:** Advances to the next clock cycle in sequential execution mode  
- **DOWN Button:** Generates a _UART trigger_ to output the current `PC value` and `instruction value`  
- **LEFT Button:** Generates a _UART trigger_ to output the currently written `register address` and its corresponding `data value`  
- **RIGHT Button:** Generates a _UART trigger_ to output the current `ALU result`  

These _UART trigger_ outputs feed into the **UART Debug Controller** module, enabling real-time transmission of signal values via UART. This allows users to observe and verify the behavior of the ***RV32I46F_5SP*** processor during FPGA verification.

Logic's test has been verified without its individual testbench by performing Synthesis, Implementation, bitstream generation, and FPGA download, subsequently running and testing it within the top-level SoC module in Vivado.