### PR TITLE
[Feat] Implement UART TX for 46F5SP_SoC_TOP FPGA verification and debugging

### DIFF
--- a/RV32I/modules/UART_TX.v
+++ b/RV32I/modules/UART_TX.v
@@ -1,0 +1,52 @@
+module UARTTX (
+    input clk,
+    input reset,
+    input tx_start,         // Transmit start signal
+    input [7:0] tx_data,    // Transmit data
+
+    output reg tx,          // UART TX pin
+    output reg tx_busy      // Transmitting flag
+);
+
+    // 115200 baud @ 50MHz = 434 clk
+    localparam BAUD_DIV = 434;
+    localparam BITS = 10; // start + 8 data + stop
+
+    reg [15:0] baud_counter;
+    reg [3:0] bit_counter;
+    reg [9:0] shift_reg;
+
+    always @(posedge clk or posedge reset) begin
+        if (reset) begin
+            tx <= 1'b1;
+            tx_busy <= 1'b0;
+            baud_counter <= 1'b0;
+            bit_counter <= 1'b0;
+            shift_reg <= 10'h3FF;
+        end else begin
+            if (!tx_busy && tx_start) begin
+                // Start : start(0) + data + stop(1)
+                shift_reg <= {1'b1, tx_data, 1'b0};
+                tx_busy <= 1'b1;
+                baud_counter <= 1'b0;
+                bit_counter <= 1'b0;
+            end else if (tx_busy) begin
+                if (baud_counter >= BAUD_DIV-1) begin
+                    baud_counter <= 0;
+                    tx <= shift_reg[0];
+                    shift_reg <= {1'b1, shift_reg[9:1]};
+
+                    if (bit_counter >= BITS-1) begin
+                        tx_busy <= 1'b0;
+                        tx <= 1'b1;
+                    end else begin
+                        bit_counter <= bit_counter + 1;
+                    end
+                end else begin
+                    baud_counter <= baud_counter +1;
+                end
+            end
+        end
+    end
+    
+endmodule


### PR DESCRIPTION
## UART TX 구현
**46F5SP_SoC_TOP** 모듈의 FPGA 구현과 실시간 검증, 디버깅을 위해서 **UART TX** 모듈이 추가되었습니다.
이 모듈은 46F5SP_SoC_TOP 모듈이 FPGA에 다운로드 된 후, FPGA 보드의 데이터를 UART 통신으로 출력하기 위한 모듈입니다.

Digilent 社의 Nexys Video FPGA 보드에 탑재된 UART Bridge (FTDI FT232R USB-UART bridge)를 사용합니다. 

50MHz 동작 클럭에 맞춰 115200 baud로 설정했습니다. 
PC로 출력될 `tx_data`는 **UART Debug Controller**에게서 입력받아 처리됩니다.

이를 통해 ***RV32I46F_5SP*** 프로세서의 동작을 UART 통신 인터페이스를 통해 FPGA 검증 과정에서 확인할 수 있습니다. 

Vivado에서 Synthesis, Implementation, 실제 FPGA bitstream generate 및 download 후 SoC 구동을 통해 모듈의 개별적인 testbench 없이 검증되었습니다.

## UART TX

**UART TX** module has been added to the **46F5SP_SoC_TOP** for FPGA implementation, runtime verification, and debugging. This module facilitates UART communication to output data from the FPGA after the 46F5SP_SoC_TOP module is downloaded onto the board.

The implementation leverages the built-in UART bridge (FTDI FT232R USB-UART bridge) on the Digilent Nexys Video FPGA board.

The UART TX module is configured to operate at a baud rate of **115200**, synchronized with the **50MHz** system clock.  
The transmission data (`tx_data`) sent to a connected PC is provided by the **UART Debug Controller** module.

This UART interface enables real-time monitoring and verification of the ***RV32I46F_5SP*** processor behavior during FPGA validation.

Logic's test has been verified without its individual testbench by performing Synthesis, Implementation, bitstream generation, and FPGA download, subsequently running and testing it within the top-level SoC module in Vivado.