### PR TITLE
[Feat] Implement RV32I46F_5SP FPGA debug SoC Top module for FPGA verification

### DIFF
--- a/RV32I/modules/46F5SP_SoC_TOP.v
+++ b/RV32I/modules/46F5SP_SoC_TOP.v
@@ -1,0 +1,244 @@
+`include "modules/RV32I46F_5SP_Debug.v"
+`include "modules/Button_Controller.v"
+`include "modules/UART_TX.v"
+`include "modules/UART_Debug_Controller.v"
+
+module RV32I46F5SPSoCTOP #(
+    parameter XLEN = 32
+)(
+    input clk,                      // 100MHz system clock from Nexys Video
+    input reset_n,                  // System reset (active low)
+    
+    // Button Interface (Nexys Video)
+    input btn_center,               // Single step execution
+    input btn_up,                   // Continuous Execution / Pause
+    input btn_down,                 // UART trigger for transmitting current pc & instruction value
+    input btn_left,                 // UART trigger for transmitting current write register address and write value
+    input btn_right,                // UART trigger for transmitting EX Phase ALU result value
+    
+    // LED state indicator
+    output [7:0] led,                // states LED
+    
+    // UART Interface
+    output uart_tx_in                  // UART TX pin
+);
+
+    // Clock Divider: 100MHz -> 50MHz
+    reg clk_50mhz_unbuffered;
+    wire clk_50mhz;
+    wire reset = ~reset_n;
+    
+    BUFG clk_50mhz_bufg (               // Automatically synthesized in Vivado without `include module
+        .I(clk_50mhz_unbuffered),
+        .O(clk_50mhz)
+    );
+    
+    always @(posedge clk or posedge reset) begin
+        if (reset) begin
+            clk_50mhz_unbuffered <= 1'b0;
+        end else begin
+            clk_50mhz_unbuffered <= ~clk_50mhz_unbuffered;
+        end
+    end
+
+    // Clock enable control
+    reg cpu_clk_enable;
+    reg [1:0] step_state;
+    wire cpu_clk;
+    assign cpu_clk = (cpu_clk_enable | continuous_mode);
+    
+    // Button control signals  
+    wire step_pulse;                // Single step execution pulse
+    wire continuous_mode;           // Continuous execution mode
+    wire pc_inst_trigger;
+    wire reg_trigger;
+    wire alu_trigger;
+    
+    // UART signals
+    wire tx_start;
+    wire [7:0] tx_data;
+    wire tx_busy;
+    
+    // CPU Internal states debug signals
+    wire [31:0] pc_value;
+    wire [31:0] current_instruction;
+    wire [31:0] selected_reg_value;
+    wire [4:0] debug_reg_addr_wire;
+    wire [31:0] debug_reg_data_wire;
+    /*
+    // Pipeline Debug signals
+    wire [31:0] debug_if_pc_wire, debug_id_pc_wire, debug_ex_pc_wire;
+    wire [31:0] debug_mem_pc_wire, debug_wb_pc_wire;
+    wire [31:0] debug_if_instruction_wire, debug_id_instruction_wire;
+    wire [31:0] debug_ex_instruction_wire, debug_mem_instruction_wire;
+    wire [31:0] debug_wb_instruction_wire;
+    
+    // Control Signals
+    wire debug_pipeline_stall_wire;
+    wire debug_branch_taken_wire;
+    wire debug_jump_taken_wire;
+    wire debug_trap_occurred_wire;
+    */
+    // ALU Signals
+    wire [31:0] debug_alu_result_wire; /*
+    wire [31:0] debug_alu_src_a_wire;
+    wire [31:0] debug_alu_src_b_wire;
+    
+    // Memory Signals
+    wire [31:0] debug_mem_addr_wire;
+    wire [31:0] debug_mem_write_data_wire;
+    wire [31:0] debug_mem_read_data_wire;
+    wire debug_mem_write_enable_wire;
+    wire debug_mem_read_enable_wire;
+    */
+    // internal reset control signals
+    wire internal_reset;
+    reg reset_sync [0:2];
+    assign internal_reset = reset_sync[2];
+    
+    // CPU states LED Indicator
+    assign led[0] = current_instruction[0];
+    assign led[1] = current_instruction[1];
+    assign led[2] = current_instruction[2];
+    assign led[3] = current_instruction[3];
+    assign led[4] = current_instruction[4];
+    assign led[5] = current_instruction[5];
+    assign led[6] = current_instruction[6];
+    assign led[7] = current_instruction[7];
+
+    // Module instances
+    ButtonController button_controller (
+        .clk(clk_50mhz),               // 50MHz
+        .reset(internal_reset),
+        
+        .btn_center(btn_center),
+        .btn_up(btn_up),
+        .btn_down(btn_down),
+        .btn_left(btn_left),
+        .btn_right(btn_right),
+        
+        .step_pulse(step_pulse),
+        .continuous_mode(continuous_mode),
+        .pc_inst_trigger(pc_inst_trigger),
+        .reg_trigger(reg_trigger),
+        .alu_trigger(alu_trigger)
+    );
+
+    // UART Transmitter
+    UARTTX uart_tx (
+        .clk(clk_50mhz),
+        .reset(internal_reset),
+        .tx_start(tx_start),
+        .tx_data(tx_data),
+        .tx(uart_tx_in),
+        .tx_busy(tx_busy)
+    );
+    
+    // Debug UART Controller
+    DebugUARTController debug_uart_controller (
+        .clk(clk_50mhz),
+        .reset(internal_reset),
+        .pc_inst_trigger(pc_inst_trigger),
+        .reg_trigger(reg_trigger),
+        .alu_trigger(alu_trigger),
+        .debug_pc(pc_value),
+        .debug_instruction(current_instruction),
+        .debug_reg_addr(debug_reg_addr_wire),
+        .debug_reg_data(debug_reg_data_wire),
+        .debug_alu_result(debug_alu_result_wire),
+        .tx_start(tx_start),
+        .tx_data(tx_data),
+        .tx_busy(tx_busy)
+    );
+    
+    // CPU - clock enable
+    RV32I46F5SPDebug #(.XLEN(XLEN)) rv32i46f_5sp_debug (
+        .clk(clk_50mhz),           // 50MHz
+        .clk_enable(cpu_clk),
+        .reset(internal_reset),
+
+        .debug_pc(pc_value),
+        .debug_instruction(current_instruction),
+        .debug_reg_addr(debug_reg_addr_wire),
+        .debug_reg_data(debug_reg_data_wire),
+        /*
+        // Pipeline states
+        .debug_if_pc(debug_if_pc_wire),
+        .debug_id_pc(debug_id_pc_wire),
+        .debug_ex_pc(debug_ex_pc_wire),
+        .debug_mem_pc(debug_mem_pc_wire),
+        .debug_wb_pc(debug_wb_pc_wire),
+        
+        .debug_if_instruction(debug_if_instruction_wire),
+        .debug_id_instruction(debug_id_instruction_wire),
+        .debug_ex_instruction(debug_ex_instruction_wire),
+        .debug_mem_instruction(debug_mem_instruction_wire),
+        .debug_wb_instruction(debug_wb_instruction_wire),
+        
+        // Control Signals
+        .debug_pipeline_stall(debug_pipeline_stall_wire),
+        .debug_branch_taken(debug_branch_taken_wire),
+        .debug_jump_taken(debug_jump_taken_wire),
+        .debug_trap_occurred(debug_trap_occurred_wire),
+        */
+        // ALU execution
+        .debug_alu_result(debug_alu_result_wire)/*, 
+        .debug_alu_src_a(debug_alu_src_a_wire),
+        .debug_alu_src_b(debug_alu_src_b_wire),
+        
+        // Memory Access
+        .debug_mem_addr(debug_mem_addr_wire),
+        .debug_mem_write_data(debug_mem_write_data_wire),
+        .debug_mem_read_data(debug_mem_read_data_wire),
+        .debug_mem_write_enable(debug_mem_write_enable_wire),
+        .debug_mem_read_enable(debug_mem_read_enable_wire)*/
+    );
+    
+    // Synchronous Reset
+    always @(posedge clk_50mhz or posedge reset) begin
+        if (reset) begin
+            reset_sync[0] <= 1'b1;
+            reset_sync[1] <= 1'b1;
+            reset_sync[2] <= 1'b1;
+        end else begin
+            reset_sync[0] <= 1'b0;
+            reset_sync[1] <= reset_sync[0];
+            reset_sync[2] <= reset_sync[1];
+        end
+    end
+    
+    // CPU Clock enable control Logics
+    always @(posedge clk_50mhz or posedge internal_reset) begin
+        if (internal_reset) begin
+            // CPU Debug logics
+            cpu_clk_enable <= 1'b0;
+            step_state <= 2'b00;
+            
+        end else begin
+            // CPU Step control
+            case (step_state)
+                2'b00: begin // Idle
+                    cpu_clk_enable <= 1'b0;
+                    if (step_pulse) begin
+                        step_state <= 2'b01;
+                    end else if (continuous_mode) begin
+                        cpu_clk_enable <= 1'b1;
+                    end
+                end
+                
+                2'b01: begin // Single step - enable clock
+                    cpu_clk_enable <= 1'b1;
+                    step_state <= 2'b10;
+                end
+                
+                2'b10: begin // Single step - disable clock
+                    cpu_clk_enable <= 1'b0;
+                    step_state <= 2'b00;
+                end
+                
+                default: step_state <= 2'b00;
+            endcase
+        end
+    end
+
+endmodule

--- a/RV32I/modules/46F5SP_SoC_TOP.v
+++ b/RV32I/modules/46F5SP_SoC_TOP.v
@@ -1,7 +1,7 @@
 `include "modules/RV32I46F_5SP_Debug.v"
 `include "modules/Button_Controller.v"
 `include "modules/UART_TX.v"
-`include "modules/UART_Debug_Controller.v"
+`include "modules/Debug_UART_Controller.v"
 
 module RV32I46F5SPSoCTOP #(
     parameter XLEN = 32

--- a/RV32I/modules/46F5SP_SoC_TOP.v
+++ b/RV32I/modules/46F5SP_SoC_TOP.v
@@ -62,35 +62,12 @@ module RV32I46F5SPSoCTOP #(
     // CPU Internal states debug signals
     wire [31:0] pc_value;
     wire [31:0] current_instruction;
-    wire [31:0] selected_reg_value;
     wire [4:0] debug_reg_addr_wire;
     wire [31:0] debug_reg_data_wire;
-    /*
-    // Pipeline Debug signals
-    wire [31:0] debug_if_pc_wire, debug_id_pc_wire, debug_ex_pc_wire;
-    wire [31:0] debug_mem_pc_wire, debug_wb_pc_wire;
-    wire [31:0] debug_if_instruction_wire, debug_id_instruction_wire;
-    wire [31:0] debug_ex_instruction_wire, debug_mem_instruction_wire;
-    wire [31:0] debug_wb_instruction_wire;
-    
-    // Control Signals
-    wire debug_pipeline_stall_wire;
-    wire debug_branch_taken_wire;
-    wire debug_jump_taken_wire;
-    wire debug_trap_occurred_wire;
-    */
+
     // ALU Signals
-    wire [31:0] debug_alu_result_wire; /*
-    wire [31:0] debug_alu_src_a_wire;
-    wire [31:0] debug_alu_src_b_wire;
-    
-    // Memory Signals
-    wire [31:0] debug_mem_addr_wire;
-    wire [31:0] debug_mem_write_data_wire;
-    wire [31:0] debug_mem_read_data_wire;
-    wire debug_mem_write_enable_wire;
-    wire debug_mem_read_enable_wire;
-    */
+    wire [31:0] debug_alu_result_wire;
+
     // internal reset control signals
     wire internal_reset;
     reg reset_sync [0:2];
@@ -161,37 +138,8 @@ module RV32I46F5SPSoCTOP #(
         .debug_instruction(current_instruction),
         .debug_reg_addr(debug_reg_addr_wire),
         .debug_reg_data(debug_reg_data_wire),
-        /*
-        // Pipeline states
-        .debug_if_pc(debug_if_pc_wire),
-        .debug_id_pc(debug_id_pc_wire),
-        .debug_ex_pc(debug_ex_pc_wire),
-        .debug_mem_pc(debug_mem_pc_wire),
-        .debug_wb_pc(debug_wb_pc_wire),
-        
-        .debug_if_instruction(debug_if_instruction_wire),
-        .debug_id_instruction(debug_id_instruction_wire),
-        .debug_ex_instruction(debug_ex_instruction_wire),
-        .debug_mem_instruction(debug_mem_instruction_wire),
-        .debug_wb_instruction(debug_wb_instruction_wire),
-        
-        // Control Signals
-        .debug_pipeline_stall(debug_pipeline_stall_wire),
-        .debug_branch_taken(debug_branch_taken_wire),
-        .debug_jump_taken(debug_jump_taken_wire),
-        .debug_trap_occurred(debug_trap_occurred_wire),
-        */
-        // ALU execution
-        .debug_alu_result(debug_alu_result_wire)/*, 
-        .debug_alu_src_a(debug_alu_src_a_wire),
-        .debug_alu_src_b(debug_alu_src_b_wire),
-        
-        // Memory Access
-        .debug_mem_addr(debug_mem_addr_wire),
-        .debug_mem_write_data(debug_mem_write_data_wire),
-        .debug_mem_read_data(debug_mem_read_data_wire),
-        .debug_mem_write_enable(debug_mem_write_enable_wire),
-        .debug_mem_read_enable(debug_mem_read_enable_wire)*/
+
+        .debug_alu_result(debug_alu_result_wire)
     );
     
     // Synchronous Reset


### PR DESCRIPTION
# 46F5SP SoC 탑 모듈 구현
본 모듈은, ***RV32I46F_5SP*** 프로세서의 FPGA 구현 및 검증을 위해 구성한 **Button Controller**, **UART TX**, **Debug UART Controller**, **RV32I46F_5SP_Debug** 모듈의 탑 모듈, SoC입니다. 

다음과 같은 기능을 수행할 수 있습니다.
## 46F5SP SoC 기능

### 입출력
**Digilent** 社의 **Nexys Video FPGA** 보드에 탑재된 총 5개의 버튼을 모두 사용하며, 각 버튼 별 할당된 역할은 다음과 같습니다.
- **위 버튼** 연속 실행 모드 / 순차 실행 모드 토글 스위치
- **중앙 버튼** 순차 실행 시 다음 클럭 사이클로 이동
- **아래 버튼** 현재 `PC 값`과 `명령어 값`을 UART로 출력하기 위한 *UART trigger* 출력
- **왼쪽 버튼** 쓰여지는 `레지스터의 주소 값`과 `데이터 값`을 UART로 출력하기 위한 *UART trigger* 출력
- **오른쪽 버튼** `ALU의 결과 값`을 UART로 출력하기 위한 *UART trigger* 출력

내장된 8개의 LED 소자에는 IF단계에 있는 명령어의 [7:0] 비트 값이 각각 출력됩니다.

**UART TX**가 구현되어, 115200 baud를 통해 PC의 UART 통신하여 버튼으로 입력한 명령을 처리한 값을 출력받을 수 있습니다.

![image](https://github.com/user-attachments/assets/4360d739-3967-40b5-b66c-8cedf2430226)

## 46F5SP SoC를 위한 수정소요
순차 실행 모드 디버깅을 위해 `clk_enable`신호가 `clk`신호를 기반으로 작동하는 모듈들에 추가되었으며,
위에서 언급한 핵심 모듈들 또한 추가로 구현되었습니다.
이에 대한 변경사항 및 적용 내용은 PR에서 자세한 내용을 확인할 수 있습니다.

### [추가 구현 모듈]
- **Button Controller** : #168 
- **UART TX** : #170 
- **Debug_UART_Controller** : #171 
- **RV32I46F_5SP_Debug** : #167 

### [`clk_enable` 추가 모듈]
- **Program Counter** : #160 
- **Hazard Unit** : #161 
- **Exception Detector** : #162 
- **Pipeline Registers** : #163 
- **Data Memory** #164 
- **CSR File** #165 
- **Branch Predictor** #166 

### [Debug 추가 모듈]
입력 및 출력에 대한 신호가 아니라, 해당 모듈 내부의 값을 직접 모니터링 / 디버깅 하기 위하여 output을 별도로 만들었습니다.
- **Register File Debug** #159 

Vivado에서 Synthesis, Implementation, 실제 FPGA bitstream generate 및 download 후 SoC 구동을 통해 모듈의 개별적인 testbench 없이 검증되었습니다.

# Implement 46F5SP SoC Top Module

This top-level SoC module integrates the **Button Controller**, **UART TX**, **Debug UART Controller**, and **RV32I46F_5SP_Debug** modules, designed to enable FPGA implementation, verification, and debugging of the ***RV32I46F_5SP*** processor.

The 46F5SP SoC provides the following functionalities:

## 46F5SP SoC Features

### Input/Output Controls
All five buttons on the **Digilent Nexys Video FPGA** board are utilized and assigned specific roles as follows:
- **UP Button:** Toggles between continuous execution mode and sequential (step-by-step) execution mode.
- **CENTER Button:** Advances the processor to the next clock cycle in sequential execution mode.
- **DOWN Button:** Generates a *UART trigger* to transmit the current `PC value` and `instruction value` via UART.
- **LEFT Button:** Generates a *UART trigger* to transmit the currently written `register address` and corresponding `data value` via UART.
- **RIGHT Button:** Generates a *UART trigger* to transmit the current `ALU result` via UART.

The onboard array of 8 LEDs displays bits [7:0] of the instruction currently at the IF (Instruction Fetch) stage.

The implemented **UART TX** module communicates with a connected PC via UART at a baud rate of 115200, allowing users to receive output data triggered by button inputs.

![image](https://github.com/user-attachments/assets/4360d739-3967-40b5-b66c-8cedf2430226)

## Required Modifications for 46F5SP SoC
A `clk_enable` signal has been added to modules operating on the primary `clk` signal to facilitate sequential mode debugging. The mentioned core modules above were also implemented accordingly. Detailed information about these modifications and implementations is provided in their respective PRs listed below.

### [Additional Implemented Modules]
- **Button Controller**: #168  
- **UART TX**: #170  
- **Debug UART Controller**: #171  
- **RV32I46F_5SP_Debug**: #167  

### [Modules Enhanced with `clk_enable` Signal]
- **Program Counter**: #160  
- **Hazard Unit**: #161  
- **Exception Detector**: #162  
- **Pipeline Registers**: #163  
- **Data Memory**: #164  
- **CSR File**: #165  
- **Branch Predictor**: #166  

### [Additional Debug Module]
A dedicated debug variant module for monitoring and debugging internal states directly (not limited to input/output signals):
- **Register File Debug**: #159

Logic's test has been verified without its individual testbench by performing Synthesis, Implementation, bitstream generation, and FPGA download, subsequently running and testing it within the top-level SoC module in Vivado.