### PR TITLE
[Feat] Revise PC Controller next pc logic source priorities

### DIFF
--- a/RV32I/modules/PC_Controller.v
+++ b/RV32I/modules/PC_Controller.v
@@ -18,14 +18,14 @@ module PCController (
 			if (trapped) begin
 				next_pc = trap_target;
 			end
+			else if (trapped == 1'b0 && jump) begin
+				next_pc = jump_target;
+			end
 			else if (trapped == 1'b0 && branch_prediction_miss) begin
 				next_pc = branch_target_actual;
 			end
 			else if (trapped == 1'b0 && branch_estimation) begin
 				next_pc = branch_target;
-			end
-			else if (trapped == 1'b0 && jump) begin
-				next_pc = jump_target;
 			end
 			else begin
 				next_pc = pc + 4;


### PR DESCRIPTION
## Revise PC Controller `next_pc` selection logic

While implementing 46F5SP's Dhrystone benchmark, we found a loop going in the middle of Dhrystone benchmark.
Debug log can be found at `#[2025.06.22.]` 

Unfortunately, the capture of the simulation waveform is missing. but this occurred because of 
**PC Controller**'s `next_pc` selection logic's decision source's priority issue.
This commit solves this issue.

---
The loop:
- PC 380: addi a0, sp, 64
a0 = 1000_7fa0
s3 = 0000_0000

- PC 384: jal ra, 2232

- PC = c3c
... Program running. a0, s3 no changes.
a0 = 1000_7fa0
s3 = 0000_0000


- PC c54: jalr zero, 0(ra)

PC = 388
...
- PC 38c: addi a0, sp, 32
a0 = 1000_7f80
s3 = 0000_0000

- PC 394: jal ra, 1460

PC = 948
...
- PC 968: addi s3, zero, 1
a0 = 1000_7f80
s1 = 0000_0001
...
- PC 970: lbu a0, 2(s1)
a0 = 0000_0000
s1 = 0000_0001
...
-PC 974: jal ra, -80

PC = 924
...
-PC 940: addi a0, zero, 1
a0 = 0000_0001
s1 = 0000_0001

-PC 944 : jalr zero, 0(ra)

PC = 978 (ra was 0000_0978 at this moment)
...
- PC 97c: beq a0, s3, -16
a0 = s3, Taken.

PC = 96c
...
- PC 974: jal ra -80

PC = 924
...
- PC 940: addi a0, zero, 1
a0 = 0000_0001
s1 = 0000_0001

- PC 944 : jalr zero, 0(ra)

PC = 978
...
- PC 97c: beq a0, s3, -16
a0 = s3, Taken.

PC = 96c. Loop occur.

38c : addi a0, sp, 32 made a0 to 1000_7f80,
960: addi s1, a0, 0. s1 was 1000_7f80 at the moment
970: lbu a0, 2(s1). a0 went 0000_0000.

After these, be PC 974: jal ra, -80 PC went 924.
And 940: addi a0, zero, 1. a0 gone 0000_0001.
And again, 970 goes 0000_0000.