### PR TITLE
[Feat] Revise Instruction Memory by bringing back old testbenches

### DIFF
--- a/RV32I/modules/Instruction_Memory.v
+++ b/RV32I/modules/Instruction_Memory.v
@@ -15,7 +15,7 @@ module InstructionMemory (
 	
 	initial begin
 		// ──────────────────────────────────────────────
-		// I‑타입 ALU 명령어 (9개)
+		// I-타입 ALU 명령어 (9개)
 		// {imm[11:0], rs1, funct3, rd, OPCODE_ITYPE}
 		data[0] = {12'h2BC, 5'd0, `ITYPE_ADDI, 5'd1, `OPCODE_ITYPE};				// ADDI:  x1 = x0 + 2BC = 000002BC
 		data[1] = {12'd24,  5'd1, `ITYPE_SLLI, 5'd2, `OPCODE_ITYPE};				// SLLI:  x2 = x1 << 24 = BC000000
@@ -28,7 +28,7 @@ module InstructionMemory (
 		data[8] = {12'h0EC, 5'd5, `ITYPE_ANDI, 5'd9, `OPCODE_ITYPE};				// ANDI:  x9 = x5 AND 0EC = 000000EC
 
 		// ──────────────────────────────────────────────
-		// R‑타입 명령어 (10개)
+		// R-타입 명령어 (10개)
 		// {funct7, rs2, rs1, funct3, rd, OPCODE_RTYPE}
 		data[9]  = {7'b0000000, 5'd9, 5'd1, `RTYPE_ADDSUB, 5'd10, `OPCODE_RTYPE};	// ADD: x10 = x1 + x9 = 000003A8
 		data[10] = {7'b0100000, 5'd5, 5'd6, `RTYPE_ADDSUB, 5'd11, `OPCODE_RTYPE};	// SUB: x11 = x6 - x5 = 0BBFFB11
@@ -42,14 +42,14 @@ module InstructionMemory (
 		data[18] = {7'b0000000, 5'd11, 5'd7, `RTYPE_AND, 5'd19, `OPCODE_RTYPE};		// AND: x19 = x7 AND x11 = 0B800000
 
 		// ──────────────────────────────────────────────
-		// S‑타입 명령어 (스토어) (3개)
+		// S-타입 명령어 (스토어) (3개)
 		// {imm[11:5], rs2, rs1, funct3, imm[4:0], OPCODE_STORE}
 		data[19] = {7'd0, 5'd11, 5'd1, `STORE_SW, 5'd4, `OPCODE_STORE};				// SW: mem[x1+4 = 2C0] = (x11 = 0BBFFB11) -> 0BBFFB11	
 		data[20] = {7'd0, 5'd10, 5'd1, `STORE_SH, 5'd7, `OPCODE_STORE};				// SH: mem[x1+7 = 2C3 (write nothing)] = (x10[15:0] = 03A8) -> 0BBFFB11 // Misaligned Memory exception. NOPs and goes to Trap Handler.
 		data[21] = {7'd0, 5'd15, 5'd1, `STORE_SB, 5'd4, `OPCODE_STORE};				// SB: mem[x1+4 = 2C0] = (x15[7:0] = BC) -> 0BBFFBBC	
 
 		// ──────────────────────────────────────────────
-		// I‑타입 로드 명령어 (5개)
+		// I-타입 로드 명령어 (5개)
 		// {imm[11:0], rs1, funct3, rd, OPCODE_LOAD}
 		data[22] = {12'd5, 5'd1, `LOAD_LW, 5'd20, `OPCODE_LOAD};					// LW:  x20 = mem[x1+5 = 2C1] = 0BBFFBBC // Misaligned Memory exception. NOPs and goes to Trap Handler.	
 		data[23] = {12'd4, 5'd1, `LOAD_LH, 5'd21, `OPCODE_LOAD};					// LH:  x21 = (mem[x1+4 = 2C0])[15:0] = FBBC (FFFFFBBC)
@@ -58,24 +58,24 @@ module InstructionMemory (
 		data[26] = {12'd4, 5'd1, `LOAD_LBU, 5'd24, `OPCODE_LOAD};					// LBU: x24 = (mem[x1+4 = 2C0])[7:0] = BC (000000BC)
 
 		// ──────────────────────────────────────────────
-		// U‑타입 명령어 (2개)
+		// U-타입 명령어 (2개)
 		// {imm[31:12], rd, OPCODE_LUI/OPCODE_AUIPC}
 		data[27] = {20'd1, 5'd25, `OPCODE_LUI};										// LUI: x25 = 00001000		
 		data[28] = {20'd1, 5'd26, `OPCODE_AUIPC};									// AUIPC: x26 = 00000070 + 00001000 = 00001070		
 
 		// ──────────────────────────────────────────────
-		// J‑타입 명령어 (1개)
+		// J-타입 명령어 (1개)
 		// {imm[20|10:1|11|19:12], rd, OPCODE_JAL}
 		data[29] = {20'b0_0000001111_0_00000000, 5'd27, `OPCODE_JAL};				// JAL: PC + 0000001E = 00000092 (but jump to 00000090), x27 = PC + 4 = 00000078
 		// But since this instruction occurs exception, It's handled as NOP.
 
 		// ──────────────────────────────────────────────
-		// I‑타입 점프 (JALR) 명령어 (1개)
+		// I-타입 점프 (JALR) 명령어 (1개)
 		// {imm[11:0], rs1, funct3, rd, OPCODE_JALR}
 		data[36] = {12'd0, 5'd27, 3'b000, 5'd28, `OPCODE_JALR}; 					// JALR: x28 = PC + 4 = 00000094; PC = x27 + 00000000 = 00000078
 
 		// ──────────────────────────────────────────────
-		// B‑타입 명령어 (분기) (6개)
+		// B-타입 명령어 (분기) (6개)
 		// {imm[12], imm[10:5], rs2, rs1, funct3, imm[4:1], imm[11], OPCODE_BRANCH}
 		data[30] = {1'b0, 6'd0, 5'd2, 5'd1, `BRANCH_BEQ, 4'b0100, 1'b0, `OPCODE_BRANCH}; 	// BEQ: if(x1 == x2) branch offset = 8		Not Taken	
 		data[31] = {1'b0, 6'd0, 5'd13, 5'd0, `BRANCH_BNE, 4'b0100, 1'b0, `OPCODE_BRANCH}; 	// BNE: if(x0 != x13) branch offset = 8		Not Taken
@@ -89,10 +89,10 @@ module InstructionMemory (
 		// {imm[11:0], rs1(uimm), funct3, rd, OPCODE_ENVIRONMENT}					   ┌-> Illegal instruction, F11 is not writable but only READ now.
 		data[37] = {12'hF11, 5'd28, `CSR_CSRRW, 5'd20, `OPCODE_ENVIRONMENT}; 		// CSRRW : x28 = 0000_0000; x20 = 5256_4B43 <= CSR[F11] = 5256_4B43 // R[x20] = 5256_4B43.
 		data[38] = {12'h341, 5'd1, `CSR_CSRRS, 5'd21, `OPCODE_ENVIRONMENT}; 		// CSRRS: x1 = 0000_02BC; CSR[341] = 0000_0074. 					// R[x21] = 0000_0074, CSR[341] = 0000_02fc
-		data[39] = {12'h341, 5'd20, `CSR_CSRRC, 5'd21, `OPCODE_ENVIRONMENT}; 		// CSRRC: x21 = 0000_0074, x20 = 5256_4B43, CSR[341] = 0000_02fc. 	// R[x21] = 0000_02fc, CSR[341] = 0000_00BC // Verified
+		data[39] = {12'h341, 5'd20, `CSR_CSRRC, 5'd21, `OPCODE_ENVIRONMENT}; 		// CSRRC: x21 = 0000_0074, x20 = 5256_4B43, CSR[341] = 0000_02fc. 	// R[x21] = 0000_02fc, CSR[341] = 0000_00BC 
 		data[40] = {12'h342, 5'd3, `CSR_CSRRWI, 5'd22, `OPCODE_ENVIRONMENT}; 		// CSRRWI: x22 = FFFF_FFBC, CSR[342] = 0000_0000; 					// R[x22] = 0000_0000, CSR[342] = 0000_0003
 		data[41] = {12'h305, 5'd7, `CSR_CSRRSI, 5'd22, `OPCODE_ENVIRONMENT}; 		// CSRRSI: x22 = 0000_0000, CSR[305] = 0000_1000; 					// R[x22] = 0000_1000, CSR[305] = 0000_1007
-		data[42] = {12'h305, 5'b11111, `CSR_CSRRCI, 5'd23, `OPCODE_ENVIRONMENT}; 	// CSRRCI: uimm = 11111, CSR[305] = 0000_1007; 						// R[x23] = 0000_1007, CSR[305] = 0000_1000
+		data[42] = {12'h305, 5'b11111, `CSR_CSRRCI, 5'd23, `OPCODE_ENVIRONMENT}; 	// CSRRCI: uimm = 11111, CSR[305] = 0000_1007; 						// R[x23] = 0000_1007, CSR[305] = 0000_1000 // CSR Verified but not REG
 		// ──────────────────────────────────────────────
 		// I-타입 HINT 명령어 (CSR 동작 확인)
 		// {imm[11:0], rs1, funct3, rd, OPCODE_ITYPE}
@@ -105,7 +105,7 @@ module InstructionMemory (
 		
 		// ──────────────────────────────────────────────
 		// Debug Interface 명령어 수행을 위한 전초 작업. 기존 x22 값 FFFF_FFBC 값을 더하는 ADD 명령어를 DI에서 수행할 예정
-		data[47] = {20'd0, 5'd22, `OPCODE_LUI};										// LUI: x22 = FFFF_F000
+		data[47] = {20'd0, 5'd22, `OPCODE_LUI};										// LUI: x22 = 0000_0000
 		data[48] = {12'hFBC, 5'd22, `ITYPE_ADDI, 5'd22, `OPCODE_ITYPE};				// ADDI x22 = x22 -FBC = FFFF_FFBC
 		data[49] = {20'hABADC, 5'd23, `OPCODE_LUI};									// LUI: x23 = ABAD_C000
 		data[50] = {12'hB02, 5'd23, `ITYPE_ADDI, 5'd23, `OPCODE_ITYPE};				// ADDI:  x23 = x23 + -4FE = ABAD_BB02
@@ -122,29 +122,25 @@ module InstructionMemory (
 		data[1024] = {12'h342, 5'd0, 3'b010, 5'd6, `OPCODE_ENVIRONMENT}; 					// csrrs x6, mcause, x0:	레지스터 x6에 mcause값 적재
 		data[1025] = {12'd11, 5'd0, `ITYPE_ADDI, 5'd7, `OPCODE_ITYPE};						// addi x7, x0, 11: 		레지스터 x7에 ECALL 코드 값 11 적재 (mcause가 11인지 비교하기 위해서는 해당 11이라는 값을 레지스터 넣고 레지스터끼리 비교해야하므로)	
 		data[1026] = {12'd2, 5'd0, `ITYPE_ADDI, 5'd8, `OPCODE_ITYPE};						// addi x8, x0, 2: 			레지스터 x8에 ILLEGAL INSTRUCTION 코드 값 2 적재 (mcause가 2인지 비교하기 위해서는 해당 2이라는 값을 레지스터 넣고 레지스터끼리 비교해야하므로)	
-		data[1027] = {12'd4, 5'd0, `ITYPE_ADDI, 5'd9, `OPCODE_ITYPE};						// addi x9, x0, 4: 			레지스터 x8에 MISALIGNED LOAD 코드 값 4 적재 (mcause가 2인지 비교하기 위해서는 해당 2이라는 값을 레지스터 넣고 레지스터끼리 비교해야하므로)	
-		data[1028] = {12'd6, 5'd0, `ITYPE_ADDI, 5'd10, `OPCODE_ITYPE};						// addi x10, x0, 6: 		레지스터 x8에 MISALIGNED STORE 코드 값 6 적재 (mcause가 2인지 비교하기 위해서는 해당 2이라는 값을 레지스터 넣고 레지스터끼리 비교해야하므로)	
 
 		// mcause 분석해서 해당하는 Trap Handler 주소로 분기
-		data[1029] = {1'b0, 6'd0, 5'd7, 5'd6, `BRANCH_BEQ, 4'b1100, 1'b0, `OPCODE_BRANCH};	// beq x6, x7, +24: 		ECALL; x6과 x7이 같다면 12바이트 이후 주솟값으로 분기 = data[1031]
-		data[1030] = {1'b0, 6'd0, 5'd0, 5'd6, `BRANCH_BEQ, 4'b1110, 1'b0, `OPCODE_BRANCH};	// beq x6, x0, +28: 		MISALIGNED INSTRUCTION; x6값이 0과 같다면 16바이트 이후 주솟값으로 분기 = data[1033]
-		data[1031] = {1'b0, 6'd0, 5'd10, 5'd6, `BRANCH_BEQ, 4'b1100, 1'b0, `OPCODE_BRANCH};	// beq x6, x10, +24: 		MISALIGNED STORE; x6값이 0과 같다면 16바이트 이후 주솟값으로 분기 = data[1033]
-		data[1032] = {1'b0, 6'd0, 5'd9, 5'd6, `BRANCH_BEQ, 4'b1010, 1'b0, `OPCODE_BRANCH};	// beq x6, x9, +20: 		MISALIGNED LOAD; x6값이 0과 같다면 16바이트 이후 주솟값으로 분기 = data[1033]
-		data[1033] = {1'b0, 6'd0, 5'd8, 5'd6, `BRANCH_BEQ, 4'b1000, 1'b0, `OPCODE_BRANCH};	// beq x6, x8, +16: 		ILLEGAL; x6값이 x8과 같다면 16바이트 이후 주솟값으로 분기 = data[1033]
-		data[1034] = {1'b0, 10'b000_0001_000, 1'b0, 8'b0, 5'd0, `OPCODE_JAL};				// jal x0, +16: 			TH 끝내기 (mret 명령어 주소로 가기)
+		data[1027] = {1'b0, 6'd0, 5'd7, 5'd6, `BRANCH_BEQ, 4'b1000, 1'b0, `OPCODE_BRANCH};	// beq x6, x7, +16: 		ECALL; x6과 x7이 같다면 12바이트 이후 주솟값으로 분기 = data[1031]
+		data[1028] = {1'b0, 6'd0, 5'd0, 5'd6, `BRANCH_BEQ, 4'b1010, 1'b0, `OPCODE_BRANCH};	// beq x6, x0, +20: 		MISALIGNED; x6값이 0과 같다면 16바이트 이후 주솟값으로 분기 = data[1033]
+		data[1029] = {1'b0, 6'd0, 5'd0, 5'd6, `BRANCH_BEQ, 4'b1000, 1'b0, `OPCODE_BRANCH};	// beq x6, x8, +16: 		ILLEGAL; x6값이 x8과 같다면 16바이트 이후 주솟값으로 분기 = data[1033]
+		data[1030] = {1'b0, 10'b000_0001_000, 1'b0, 8'b0, 5'd0, `OPCODE_JAL};				// jal x0, +16: 			TH 끝내기 (mret 명령어 주소로 가기)
 		
 		// ECALL Trap Handler @ data[1029]
-		data[1035] = {12'd0, 5'd0, `ITYPE_ADDI, 5'd1, `OPCODE_ITYPE};						//addi x1, x0, 0: 			레지스터 x1 값 0으로 비우기
-		data[1036] = {1'b0, 10'b000_0000_100, 1'b0, 8'b0, 5'd0, `OPCODE_JAL};				//jal x0, +8:				TH 끝내기 (mret 명령어 주소로 가기)
+		data[1031] = {12'd0, 5'd0, `ITYPE_ADDI, 5'd1, `OPCODE_ITYPE};						//addi x1, x0, 0: 			레지스터 x1 값 0으로 비우기
+		data[1032] = {1'b0, 10'b000_0000_100, 1'b0, 8'b0, 5'd0, `OPCODE_JAL};				//jal x0, +8:				TH 끝내기 (mret 명령어 주소로 가기)
 
 		// ILLEGAL / MISALIGNED Trap Handler @ data[1031]
-		data[1037] = {12'hFF, 5'd2, `ITYPE_ADDI, 5'd30, `OPCODE_ITYPE};						//addi x30, x2, 255: 		x30 레지스터에 x2(BC00_0000) + 0xFF = bc00_00ff
+		data[1033] = {12'hFF, 5'd2, `ITYPE_ADDI, 5'd30, `OPCODE_ITYPE};						//addi x30, x2, 255: 		x30 레지스터에 x2(BC00_0000) + 0xFF = bc00_00ff
 
 		// ESCAPE Trap Handler @ data[1032]
-		data[1038] = {12'b001100000010, 5'b0, 3'b0, 5'b0, `OPCODE_ENVIRONMENT};				//MRET:						PC = CSR[mepc]
+		data[1034] = {12'b001100000010, 5'b0, 3'b0, 5'b0, `OPCODE_ENVIRONMENT};				//MRET:						PC = CSR[mepc]
 
 		// HINT; NOP for 'x' signal after MRET in pipeline
-		data[1039] = {12'h2BC, 5'd0, `ITYPE_ADDI, 5'd0, `OPCODE_ITYPE};						// ADDI:  x0 = x0 + 2BC = 0000_0000
+		data[1035] = {12'h2BC, 5'd0, `ITYPE_ADDI, 5'd0, `OPCODE_ITYPE};						// ADDI:  x0 = x0 + 2BC = 0000_0000
 	end
 	
 	always @(*) begin


### PR DESCRIPTION
## Revise Core Test scenario in Instruction Memory
Previously, we've revised core testing scenario integrated in **Instruction Memory** for revising support of ***misaligned memory access*** which has been separated to **Misaligned Store** and **Misaligned Load**. 
- #152 

But, while verifying the total logics on FPGA, it showed unexpected behavior such as stalling and resetting register value to 0 after the misaligned store exception. 
Since the deadline is near, I decided to delay resolving this issue. It will be added to **Issues**.
This commit brings back the ***old Misaligned Memory Access*** Trap Handler.